### PR TITLE
fix assignments script output bug

### DIFF
--- a/public/assignments.php
+++ b/public/assignments.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-require __DIR__ . '/_cli_guard.php';;
+require __DIR__ . '/_cli_guard.php';
 
 require_once __DIR__ . '/../config/database.php';
-require_once __DIR__ . '/../partials/assignments_toast_hook.php'; ?>
+require_once __DIR__ . '/../partials/assignments_toast_hook.php';
 
 
 $pdo = getPDO();


### PR DESCRIPTION
## Summary
- remove stray PHP closing tag to ensure assignments endpoint executes

## Testing
- `vendor/bin/phpunit` *(fails: Test directory "/workspace/FieldOps/tests/Unit" not found)*
- `vendor/bin/phpstan analyse --memory-limit=512M` *(fails: Found 76 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dd99e9838832f93b855a25dc6cdb4