### PR TITLE
Add CSRF helper functions

### DIFF
--- a/helpers/csrf_helpers.php
+++ b/helpers/csrf_helpers.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+// CSRF helper functions. Ensures a session token exists and can be
+// verified against incoming requests. Safe to include multiple times.
+
+if (!function_exists('csrf_token')) {
+    /**
+     * Get the current CSRF token, generating one if needed.
+     */
+    function csrf_token(): string {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        if (!isset($_SESSION['csrf_token']) || !is_string($_SESSION['csrf_token']) || $_SESSION['csrf_token'] === '') {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(16));
+        }
+        return (string)$_SESSION['csrf_token'];
+    }
+}
+
+if (!function_exists('csrf_verify')) {
+    /**
+     * Verify the provided CSRF token against the session token.
+     */
+    function csrf_verify(?string $token): bool {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        if (!is_string($token) || $token === '') {
+            return false;
+        }
+        if (!isset($_SESSION['csrf_token']) || !is_string($_SESSION['csrf_token'])) {
+            return false;
+        }
+        return hash_equals($_SESSION['csrf_token'], $token);
+    }
+}
+
+if (!function_exists('verify_csrf_token')) {
+    /**
+     * Backwards compatible alias for csrf_verify().
+     */
+    function verify_csrf_token(?string $token): bool {
+        return csrf_verify($token);
+    }
+}
+
+?>


### PR DESCRIPTION
## Summary
- Add centralized CSRF helper functions to generate and validate tokens

## Testing
- `make lint` *(fails: Found 76 errors)*
- `make test` *(fails: make: *** [Makefile:32: unit] Error 2)*
- `make integration` *(fails: PDOException: DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ddbcce640832f8929f825c9004347