### PR TITLE
Fix job edit query to concatenate customer name

### DIFF
--- a/models/Job.php
+++ b/models/Job.php
@@ -18,7 +18,7 @@ final class Job
                 j.scheduled_time,
                 j.duration_minutes,
                 c.id   AS customer_id_actual,
-                c.name AS customer_name,
+                CONCAT(c.first_name, ' ', c.last_name) AS customer_name,
                 c.email AS customer_email,
                 c.phone AS customer_phone
             FROM jobs j


### PR DESCRIPTION
## Summary
- use first and last name when retrieving job's customer details

## Testing
- `make unit`
- `make integration` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e0242f3a4832fb58bd3d673bad8fb