### PR TITLE
Fix assign state after conflict modal

### DIFF
--- a/public/js/assignments.js
+++ b/public/js/assignments.js
@@ -423,6 +423,10 @@
             : `Some selections may have issues. Proceed anyway?`;
         }
         bootstrap?.Modal.getOrCreateInstance(document.getElementById('assignConfirmModal'))?.show();
+        // Reset posting state so the confirm button can re-trigger submission
+        isPosting = false;
+        if ($btnAssign) $btnAssign.textContent = btnLabelPrev || `Assign Selected (${selected.size})`;
+        updateSelectedCount();
         return; // stop; wait for "assign anyway"
       }
 


### PR DESCRIPTION
## Summary
- Reset posting state when conflict modal opens so "Assign Selected" can be retried

## Testing
- `make lint` *(fails: Found 77 errors)*
- `make test` *(fails: DB connection refused in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689e0fab02e0832fbb0cf6450b2fce3b