### PR TITLE
feat: add job form with customer autocomplete

### DIFF
--- a/public/api/customer_search.php
+++ b/public/api/customer_search.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../../config/database.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$q = trim((string)($_GET['q'] ?? ''));
+if (strlen($q) < 2) {
+    echo json_encode([]);
+    exit;
+}
+
+$pdo = getPDO();
+$needle = '%' . str_replace(['\\','%','_'], ['\\\\','\\%','\\_'], $q) . '%';
+$sql = "SELECT id, first_name, last_name, address_line1, city FROM customers WHERE first_name LIKE :q OR last_name LIKE :q OR address_line1 LIKE :q OR city LIKE :q ORDER BY last_name, first_name LIMIT 10";
+$st = $pdo->prepare($sql);
+$st->execute([':q' => $needle]);
+$rows = $st->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+echo json_encode($rows, JSON_UNESCAPED_SLASHES);

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -1,76 +1,188 @@
 <?php
 declare(strict_types=1);
 require __DIR__ . '/_cli_guard.php';
-
-
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/_csrf.php';
-require_once __DIR__ . '/../models/Customer.php';
-$customerModel = new Customer(getPDO());
-$customers = $customerModel->getAll();
-require_once __DIR__ . '/../models/Job.php';
-$statuses = Job::allowedStatuses();
+require_once __DIR__ . '/../models/JobType.php';
 
-$pdo = getPDO();
-$__csrf = csrf_token();
+$pdo       = getPDO();
+$jobTypes  = JobType::all($pdo);
+$statuses  = ['Scheduled', 'In Progress', 'Completed', 'Cancelled'];
+$__csrf    = csrf_token();
+$today     = date('Y-m-d');
+
+/** HTML escape */
+function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
 ?>
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Create Job</title>
+  <title>Add Job</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
-<body>
-
-<?php
-/** HTML escape */
-function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
-/** Sticky helper */
-function sticky(string $name, ?string $default = null): string {
-    $v = $_POST[$name] ?? $_GET[$name] ?? $default ?? '';
-    return is_string($v) ? $v : (string)$v;
-}
-?>
-
-  <h1>Create Job</h1>
-  <form method="post" action="job_save.php" autocomplete="off">
+<body class="p-4">
+  <h1>Add Job</h1>
+  <form method="post" action="job_save.php" id="jobForm" autocomplete="off" class="needs-validation" novalidate>
     <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
-    <fieldset>
-      <legend>Basics</legend>
-      <label>Customer
-        <select name="customer_id" required>
-          <option value="">-- Select --</option>
-          <?php foreach ($customers as $c): ?>
-            <option value="<?= (int)$c['id'] ?>"><?= s($c['first_name'] . ' ' . $c['last_name']) ?></option>
-          <?php endforeach; ?>
+
+    <!-- Section 1: Customer Information -->
+    <section class="mb-4">
+      <h2 class="h5">Customer Information</h2>
+      <div class="mb-3 position-relative">
+        <label for="customerSearch" class="form-label">Customer</label>
+        <input type="text" id="customerSearch" class="form-control" placeholder="Start typing..." required>
+        <input type="hidden" name="customer_id" id="customerId">
+        <div id="customerResults" class="list-group position-absolute w-100"></div>
+        <div class="invalid-feedback">Select a customer from the list.</div>
+      </div>
+    </section>
+
+    <!-- Section 2: Job Details -->
+    <section class="mb-4">
+      <h2 class="h5">Job Details</h2>
+      <div class="mb-3">
+        <label for="description" class="form-label">Job Description</label>
+        <textarea id="description" name="description" class="form-control" minlength="5" maxlength="255" required></textarea>
+        <div class="invalid-feedback">Description must be between 5 and 255 characters.</div>
+      </div>
+      <div class="mb-3">
+        <span class="form-label d-block mb-2">Job Types</span>
+        <div class="row row-cols-2" id="jobTypes">
+        <?php foreach ($jobTypes as $jt): ?>
+          <div class="col">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" name="job_types[]" value="<?= (int)$jt['id'] ?>" id="jt<?= (int)$jt['id'] ?>">
+              <label class="form-check-label" for="jt<?= (int)$jt['id'] ?>"><?= s($jt['name']) ?></label>
+            </div>
+          </div>
+        <?php endforeach; ?>
+        </div>
+        <div class="invalid-feedback d-block" id="jobTypeError" style="display:none">Select at least one job type.</div>
+      </div>
+    </section>
+
+    <!-- Section 3: Scheduling -->
+    <section class="mb-4">
+      <h2 class="h5">Scheduling</h2>
+      <div class="row g-3 align-items-end">
+        <div class="col-md-4">
+          <label for="scheduled_date" class="form-label">Scheduled Date</label>
+          <input type="date" id="scheduled_date" name="scheduled_date" class="form-control" min="<?= s($today) ?>">
+        </div>
+        <div class="col-md-4">
+          <label for="scheduled_time" class="form-label">Scheduled Time</label>
+          <input type="time" id="scheduled_time" name="scheduled_time" class="form-control">
+        </div>
+        <div class="col-md-4">
+          <label for="duration_minutes" class="form-label">Duration (minutes)</label>
+          <input type="number" id="duration_minutes" name="duration_minutes" class="form-control" min="1" step="1" value="60">
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 4: Status -->
+    <section class="mb-4">
+      <h2 class="h5">Status</h2>
+      <div class="mb-3">
+        <select name="status" class="form-select" required>
+        <?php foreach ($statuses as $st): ?>
+          <option value="<?= s($st) ?>"<?= $st === 'Scheduled' ? ' selected' : '' ?>><?= s($st) ?></option>
+        <?php endforeach; ?>
         </select>
-      </label>
-      <label>Description
-        <input type="text" name="description" required>
-      </label>
-      <label>Status
-        <select name="status" required>
-          <?php foreach ($statuses as $st): ?>
-            <option value="<?= s($st) ?>"><?= s($st) ?></option>
-          <?php endforeach; ?>
-        </select>
-      </label>
-    </fieldset>
-    <fieldset>
-      <legend>Schedule</legend>
-      <label>Date
-        <input type="date" name="scheduled_date" required>
-      </label>
-      <label>Time
-        <input type="time" name="scheduled_time" required>
-      </label>
-      <label>Duration (minutes)
-        <input type="number" name="duration_minutes" min="0" step="5" value="60">
-      </label>
-    </fieldset>
-    <button type="submit">Save Job</button>
+      </div>
+    </section>
+
+    <!-- Section 5: Actions -->
+    <section class="mt-4">
+      <button type="submit" class="btn btn-primary">Save Job</button>
+      <a href="jobs.php" class="btn btn-secondary">Cancel</a>
+    </section>
   </form>
 
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+  const searchInput = document.getElementById('customerSearch');
+  const resultsDiv = document.getElementById('customerResults');
+  const customerIdInput = document.getElementById('customerId');
+  let results = [];
+  let activeIndex = -1;
+
+  searchInput.addEventListener('input', async function() {
+    const q = this.value.trim();
+    customerIdInput.value = '';
+    if (q.length < 2) { resultsDiv.innerHTML = ''; return; }
+    const resp = await fetch('api/customer_search.php?q=' + encodeURIComponent(q));
+    results = await resp.json();
+    resultsDiv.innerHTML = '';
+    activeIndex = -1;
+    results.forEach((c, idx) => {
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'list-group-item list-group-item-action';
+      item.textContent = `${c.first_name} ${c.last_name} — ${c.address_line1}, ${c.city}`;
+      item.addEventListener('click', () => selectCustomer(idx));
+      resultsDiv.appendChild(item);
+    });
+  });
+
+  searchInput.addEventListener('keydown', function(e) {
+    const items = resultsDiv.querySelectorAll('.list-group-item');
+    if (e.key === 'ArrowDown') {
+      activeIndex = (activeIndex + 1) % items.length;
+      updateActive(items); e.preventDefault();
+    } else if (e.key === 'ArrowUp') {
+      activeIndex = (activeIndex - 1 + items.length) % items.length;
+      updateActive(items); e.preventDefault();
+    } else if (e.key === 'Enter' && activeIndex >= 0) {
+      selectCustomer(activeIndex); e.preventDefault();
+    }
+  });
+
+  function updateActive(items) {
+    items.forEach((el, idx) => {
+      el.classList.toggle('active', idx === activeIndex);
+    });
+  }
+
+  function selectCustomer(idx) {
+    const c = results[idx];
+    searchInput.value = `${c.first_name} ${c.last_name} — ${c.address_line1}, ${c.city}`;
+    customerIdInput.value = c.id;
+    resultsDiv.innerHTML = '';
+  }
+
+  document.getElementById('jobForm').addEventListener('submit', function(e) {
+    const jtChecks = document.querySelectorAll('input[name="job_types[]"]:checked');
+    const jobTypeError = document.getElementById('jobTypeError');
+    const timeVal = document.getElementById('scheduled_time').value;
+    const dateVal = document.getElementById('scheduled_date').value;
+    let valid = true;
+
+    if (!customerIdInput.value) {
+      searchInput.classList.add('is-invalid');
+      valid = false;
+    } else {
+      searchInput.classList.remove('is-invalid');
+    }
+
+    if (jtChecks.length === 0) {
+      jobTypeError.style.display = 'block';
+      valid = false;
+    } else {
+      jobTypeError.style.display = 'none';
+    }
+
+    if (timeVal && !dateVal) {
+      document.getElementById('scheduled_date').classList.add('is-invalid');
+      valid = false;
+    } else {
+      document.getElementById('scheduled_date').classList.remove('is-invalid');
+    }
+
+    if (!valid) e.preventDefault();
+  });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Revamp Add Job form with Bootstrap layout, customer autocomplete, job type checkboxes and optional scheduling
- Add API endpoint for customer search queries

## Testing
- `make lint` *(fails: Found 77 errors)*
- `make test` *(fails: DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_689e17eabd34832fbe9966b3cb5b61a2