### PR TITLE
Align job status handling with database enum

### DIFF
--- a/JobTest.php
+++ b/JobTest.php
@@ -15,7 +15,7 @@ class JobTest extends TestCase
                 'description' => 'Mock Job',
                 'scheduled_date' => '2025-08-07',
                 'scheduled_time' => '09:00:00',
-                'status' => 'Unassigned',
+                'status' => 'scheduled',
                 'duration_minutes' => 60,
                 'customer_id' => 10,
                 'first_name' => 'Jane',
@@ -33,7 +33,7 @@ class JobTest extends TestCase
         $mockPdo->method('prepare')->willReturn($mockStmt);
 
         // Step 3: Run the test
-        $results = Job::getFiltered($mockPdo, 'Unassigned');
+        $results = Job::getFiltered($mockPdo, 'scheduled');
 
         // Step 4: Assert the mock data is returned correctly
         $this->assertCount(1, $results);

--- a/models/Job.php
+++ b/models/Job.php
@@ -41,8 +41,8 @@ final class Job
      */
     public static function allowedStatuses(): array
     {
-        // Keep in sync with assignment_process.php status flip rules.
-        return ['Unassigned', 'Assigned', 'Completed', 'Cancelled'];
+        // Keep in sync with assignment_process.php status flip rules and DB ENUM.
+        return ['draft','scheduled','assigned','in_progress','completed','closed','cancelled'];
     }
 
     /**

--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -24,15 +24,16 @@ try {
     $statusList = array_filter(array_map('trim', explode(',', $statusParam)));
     $mappedStatuses = [];
     foreach ($statusList as $s) {
-        if (strcasecmp($s, 'Scheduled') === 0) {
-            $mappedStatuses[] = 'Assigned';
-            $mappedStatuses[] = 'Unassigned';
+        $key = str_replace(' ', '_', strtolower($s));
+        if ($key === 'scheduled') {
+            $mappedStatuses[] = 'scheduled';
+            $mappedStatuses[] = 'assigned';
         } else {
-            $mappedStatuses[] = $s;
+            $mappedStatuses[] = $key;
         }
     }
     if (!$mappedStatuses) {
-        $mappedStatuses = ['Unassigned', 'Assigned', 'In Progress'];
+        $mappedStatuses = ['scheduled', 'assigned', 'in_progress'];
     }
 
     $jobTypeParam = $_GET['job_type'] ?? '';

--- a/public/assignments_table.php
+++ b/public/assignments_table.php
@@ -10,7 +10,7 @@ $pdo = getPDO();
 // Filters (defensive defaults)
 $employeeId = (int)($_GET['employee_id'] ?? 0);
 $days       = (int)($_GET['days'] ?? 7);
-$status     = trim((string)($_GET['status'] ?? ''));   // Unassigned / Scheduled / Completed, etc.
+$status     = strtolower(str_replace(' ', '_', trim((string)($_GET['status'] ?? ''))));   // scheduled / assigned / completed, etc.
 $search     = trim((string)($_GET['search'] ?? ''));   // job desc or customer
 
 $sql = "
@@ -83,7 +83,7 @@ foreach ($rows as $r) {
 
   $jid   = (int)($r['job_id'] ?? 0);
   $desc  = htmlspecialchars((string)($r['description'] ?? ''), ENT_QUOTES, 'UTF-8');
-  $stat  = htmlspecialchars((string)($r['status'] ?? ''), ENT_QUOTES, 'UTF-8');
+  $stat  = strtolower((string)($r['status'] ?? ''));
   $date  = htmlspecialchars((string)($r['scheduled_date'] ?? ''), ENT_QUOTES, 'UTF-8');
   $time  = htmlspecialchars((string)($r['scheduled_time'] ?? ''), ENT_QUOTES, 'UTF-8');
   $dur   = (int)($r['duration_minutes'] ?? 0);
@@ -93,16 +93,17 @@ foreach ($rows as $r) {
   $types = htmlspecialchars((string)($r['job_types'] ?? ''), ENT_QUOTES, 'UTF-8');
 
   $badgeClass = 'secondary';
-  if ($stat === 'Unassigned') $badgeClass = 'danger';
-  else if ($stat === 'Scheduled') $badgeClass = 'primary';
-  else if ($stat === 'Completed') $badgeClass = 'success';
+  if ($stat === 'scheduled') $badgeClass = 'danger';
+  elseif ($stat === 'assigned') $badgeClass = 'primary';
+  elseif ($stat === 'completed') $badgeClass = 'success';
 
   echo "<tr>";
   echo "  <td class=\"text-nowrap\">#{$jid}</td>";
   echo "  <td><div class=\"fw-semibold\">{$desc}</div><div class=\"small text-muted\">{$types}</div></td>";
   echo "  <td><div>{$cust}</div><div class=\"small text-muted\">{$addr}</div></td>";
   echo "  <td class=\"text-nowrap\"><div>{$date}</div><div class=\"small text-muted\">{$time} · {$dur} min</div></td>";
-  echo "  <td><span class=\"badge bg-{$badgeClass}\">{$stat}</span></td>";
+  $label = htmlspecialchars(str_replace('_',' ', $stat), ENT_QUOTES, 'UTF-8');
+  echo "  <td><span class=\"badge bg-{$badgeClass}\">{$label}</span></td>";
   echo "  <td class=\"text-end\">";
   echo "    <button class=\"btn btn-sm btn-outline-primary me-1\" data-bs-toggle=\"modal\" data-bs-target=\"#assignModal\" data-job-id=\"{$jid}\">Assign</button>";
   echo "    <a class=\"btn btn-sm btn-outline-secondary\" href=\"edit_job.php?id={$jid}\">Edit</a>";

--- a/public/edit_job.php
+++ b/public/edit_job.php
@@ -11,7 +11,7 @@ $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $job = $id > 0 ? Job::getJobAndCustomerDetails(getPDO(), $id) : null;
 $statuses = Job::allowedStatuses();
 $jobTypes = $id > 0 ? Job::getJobTypesForJob(getPDO(), $id) : [];
-$current  = $job['status'] ?? 'Unassigned';
+$current  = strtolower((string)($job['status'] ?? 'draft'));
 
 $pdo = getPDO();
 $__csrf = csrf_token();
@@ -48,7 +48,8 @@ function sticky(string $name, ?string $default = null): string {
         <label>Status
           <select name="status" required>
             <?php foreach ($statuses as $st): ?>
-              <option value="<?= s($st) ?>" <?= $st === $current ? 'selected' : '' ?>><?= s($st) ?></option>
+              <?php $label = ucwords(str_replace('_',' ', $st)); ?>
+              <option value="<?= s($st) ?>" <?= $st === $current ? 'selected' : '' ?>><?= s($label) ?></option>
             <?php endforeach; ?>
           </select>
         </label>

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -4,10 +4,11 @@ require __DIR__ . '/_cli_guard.php';
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/_csrf.php';
 require_once __DIR__ . '/../models/JobType.php';
+require_once __DIR__ . '/../models/Job.php';
 
 $pdo       = getPDO();
 $jobTypes  = JobType::all($pdo);
-$statuses  = ['Scheduled', 'In Progress', 'Completed', 'Cancelled'];
+$statuses  = Job::allowedStatuses();
 $__csrf    = csrf_token();
 $today     = date('Y-m-d');
 
@@ -88,7 +89,8 @@ function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES,
       <div class="mb-3">
         <select name="status" class="form-select" required>
         <?php foreach ($statuses as $st): ?>
-          <option value="<?= s($st) ?>"<?= $st === 'Scheduled' ? ' selected' : '' ?>><?= s($st) ?></option>
+          <?php $label = ucwords(str_replace('_',' ', $st)); ?>
+          <option value="<?= s($st) ?>"<?= $st === 'scheduled' ? ' selected' : '' ?>><?= s($label) ?></option>
         <?php endforeach; ?>
         </select>
       </div>

--- a/public/job_save.php
+++ b/public/job_save.php
@@ -34,7 +34,6 @@ $statusIn        = trim((string)($_POST['status'] ?? ''));
 
 // Normalize status to canonical ENUM values (lowercase)
 $map = [
-  'unassigned'=>'unassigned','Unassigned'=>'unassigned','UNASSIGNED'=>'unassigned',
   'draft'=>'draft','Draft'=>'draft',
   'scheduled'=>'scheduled','Scheduled'=>'scheduled',
   'assigned'=>'assigned','Assigned'=>'assigned',
@@ -43,7 +42,7 @@ $map = [
   'closed'=>'closed','Closed'=>'closed',
   'cancelled'=>'cancelled','Canceled'=>'cancelled','Cancelled'=>'cancelled',
 ];
-$canonical = $map[$statusIn] ?? $map[str_replace('_',' ', $statusIn)] ?? 'unassigned';
+$canonical = $map[$statusIn] ?? $map[str_replace('_',' ', $statusIn)] ?? 'draft';
 
 // Validate
 $errors=[];

--- a/public/jobs_table.php
+++ b/public/jobs_table.php
@@ -29,7 +29,7 @@ function badge_class(string $status): string {
 
 // Params
 $days   = isset($_GET['days']) && is_numeric($_GET['days']) ? max(0, (int)$_GET['days']) : 30;
-$status = isset($_GET['status']) ? strtolower(trim((string)$_GET['status'])) : '';
+$status = isset($_GET['status']) ? strtolower(str_replace(' ','_',trim((string)$_GET['status']))) : '';
 $search = isset($_GET['search']) ? trim((string)$_GET['search']) : '';
 
 $pdo = getPDO();

--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -75,13 +75,16 @@
         // Status
         const statusCell=document.createElement('td');
         const sc={
-          'Unassigned':'bg-secondary-subtle text-secondary border',
-          'Assigned':'bg-primary-subtle text-primary border',
-          'In Progress':'bg-warning-subtle text-warning border',
-          'Completed':'bg-success-subtle text-success border',
-          'Cancelled':'bg-secondary-subtle text-secondary border'
+          'draft':'bg-light text-dark border',
+          'scheduled':'bg-secondary-subtle text-secondary border',
+          'assigned':'bg-primary-subtle text-primary border',
+          'in_progress':'bg-warning-subtle text-warning border',
+          'completed':'bg-success-subtle text-success border',
+          'closed':'bg-secondary-subtle text-secondary border',
+          'cancelled':'bg-secondary-subtle text-secondary border'
         };
-        statusCell.innerHTML=`<span class="badge ${sc[job.status]||'bg-light text-dark border'} badge-status">${h(job.status)}</span>`;
+        const label=job.status.replace(/_/g,' ');
+        statusCell.innerHTML=`<span class="badge ${sc[job.status]||'bg-light text-dark border'} badge-status">${h(label)}</span>`;
         tr.appendChild(statusCell);
         // Actions
         const actCell=document.createElement('td');

--- a/scripts/smoke_job_writes.sh
+++ b/scripts/smoke_job_writes.sh
@@ -65,7 +65,7 @@ curl -sS -c "$COOKIES" -b "$COOKIES" -H "Accept: application/json" \
   -d "scheduled_date=$JOBDATE" \
   -d "scheduled_time=10:00:00" \
   -d "duration_minutes=60" \
-  -d "status=unassigned" \
+  -d "status=scheduled" \
   "$BASE_URL/job_save.php?__return=json" | tee "$JOB_JSON" >/dev/null
 
 JOB_OK="$(php_json '$j=json_decode(file_get_contents("'"$JOB_JSON"'"),true); echo (isset($j["ok"])&&$j["ok"])?1:0;')"

--- a/tests/AssignmentsTest.php
+++ b/tests/AssignmentsTest.php
@@ -46,7 +46,7 @@ final class AssignmentsTest extends TestCase
         $dow        = (int)date('w', strtotime($date));
 
         TestDataFactory::setAvailability($this->pdo, $employeeId, $dow, '09:00:00', '12:00:00');
-        $jobId = TestDataFactory::createJob($this->pdo, $customerId, 'Assign happy path', $date, '10:00:00', 60, 'Unassigned');
+        $jobId = TestDataFactory::createJob($this->pdo, $customerId, 'Assign happy path', $date, '10:00:00', 60, 'scheduled');
 
         // 🔴 Important: the HTTP endpoint runs in another connection; commit fixtures so it can see them.
         $this->pdo->commit();
@@ -90,7 +90,7 @@ final class AssignmentsTest extends TestCase
         TestDataFactory::setAvailability($this->pdo, $employeeId, $dow, '09:00:00', '12:00:00');
 
         // First job: 10:00–11:00 (should succeed)
-        $jobA  = TestDataFactory::createJob($this->pdo, $customerId, 'Job A', $date, '10:00:00', 60, 'Unassigned');
+        $jobA  = TestDataFactory::createJob($this->pdo, $customerId, 'Job A', $date, '10:00:00', 60, 'scheduled');
 
         // Make fixtures visible to the endpoint
         $this->pdo->commit();
@@ -109,7 +109,7 @@ final class AssignmentsTest extends TestCase
         // Second job: 10:30–11:30 (overlaps -> should NOT persist)
         // Start a new transaction for creating B, then commit before HTTP again.
         $this->pdo->beginTransaction();
-        $jobB = TestDataFactory::createJob($this->pdo, $customerId, 'Job B', $date, '10:30:00', 60, 'Unassigned');
+        $jobB = TestDataFactory::createJob($this->pdo, $customerId, 'Job B', $date, '10:30:00', 60, 'scheduled');
         $this->pdo->commit();
 
         $second = Http::postFormJson('assignment_process.php', [

--- a/tests/Integration/AssignmentsApiTest.php
+++ b/tests/Integration/AssignmentsApiTest.php
@@ -39,7 +39,7 @@ final class AssignmentsApiTest extends TestCase
         $this->pdo->exec("INSERT INTO customers (first_name,last_name,phone,created_at) VALUES ('Assign','Tester','555-2000',NOW())");
         $this->pdo->exec("
           INSERT INTO jobs (customer_id,description,scheduled_date,scheduled_time,status,duration_minutes,created_at,updated_at)
-          VALUES (LAST_INSERT_ID(),'Assignment API Job',CURDATE(),'08:30:00','Unassigned',60,NOW(),NOW())
+          VALUES (LAST_INSERT_ID(),'Assignment API Job',CURDATE(),'08:30:00','scheduled',60,NOW(),NOW())
         ");
     }
 

--- a/tests/Integration/AssignmentsDataTest.php
+++ b/tests/Integration/AssignmentsDataTest.php
@@ -37,7 +37,7 @@ final class AssignmentsDataTest extends TestCase
 
         $this->pdo->exec("
             INSERT INTO jobs (id, customer_id, description, scheduled_date, scheduled_time, duration_minutes, status)
-            VALUES (9101, 9001, 'Assign test job', '2030-01-01', '09:00:00', 60, 'Unassigned')
+            VALUES (9101, 9001, 'Assign test job', '2030-01-01', '09:00:00', 60, 'scheduled')
             ON DUPLICATE KEY UPDATE description='Assign test job';
         ");
 

--- a/tests/Integration/JobEmployeeViewTest.php
+++ b/tests/Integration/JobEmployeeViewTest.php
@@ -37,7 +37,7 @@ final class JobEmployeeViewTest extends TestCase
 
         $date = (new DateTimeImmutable('+1 day'))->format('Y-m-d');
         $jobId = TestDataFactory::createJob(
-            $this->pdo, $custId, 'Check view mirrors assignment', $date, '10:00:00', 45, 'Unassigned'
+            $this->pdo, $custId, 'Check view mirrors assignment', $date, '10:00:00', 45, 'scheduled'
         );
 
         $stmt = $this->pdo->prepare('INSERT INTO job_employee_assignment (job_id, employee_id, assigned_at) VALUES (?,?,NOW())');

--- a/tests/Integration/JobWriteRbacTest.php
+++ b/tests/Integration/JobWriteRbacTest.php
@@ -35,7 +35,7 @@ final class JobWriteRbacTest extends TestCase
             'description'    => 'Test Job',
             'scheduled_date' => '2025-08-20',
             'scheduled_time' => '10:00',
-            'status'         => 'Unassigned',
+            'status'         => 'scheduled',
             'job_types'      => ['Window Washing'],
         ], [
             'role' => 'field_tech',
@@ -55,7 +55,7 @@ final class JobWriteRbacTest extends TestCase
             'description'    => 'Test Job',
             'scheduled_date' => '2025-08-20',
             'scheduled_time' => '10:00',
-            'status'         => 'Unassigned',
+            'status'         => 'scheduled',
             // no csrf_token on purpose
         ], [
             'role' => 'dispatcher',
@@ -75,7 +75,7 @@ final class JobWriteRbacTest extends TestCase
             'description'      => 'Initial Job',
             'scheduled_date'   => '2025-08-21',
             'scheduled_time'   => '09:30',
-            'status'           => 'Unassigned',
+            'status'           => 'scheduled',
             'duration_minutes' => 120,
             'job_types'        => ['Window Washing','Pressure Washing'],
         ], ['role' => 'dispatcher']);
@@ -95,7 +95,7 @@ final class JobWriteRbacTest extends TestCase
             'description'      => 'Updated Job Title',
             'scheduled_date'   => '2025-08-22',
             'scheduled_time'   => '14:15',
-            'status'           => 'Assigned',
+            'status'           => 'assigned',
             'duration_minutes' => 90,
             'job_types'        => ['Window Washing'],
         ], ['role' => 'dispatcher']);

--- a/tests/Integration/JobWriteValidationTest.php
+++ b/tests/Integration/JobWriteValidationTest.php
@@ -29,7 +29,7 @@ final class JobWriteValidationTest extends TestCase
             'description'    => '',
             'scheduled_date' => '',
             'scheduled_time' => '',
-            'status'         => 'Unassigned',
+            'status'         => 'scheduled',
         ], ['role' => 'dispatcher']);
 
         $this->assertFalse($res['ok'] ?? true);

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -15,7 +15,7 @@ class JobTest extends TestCase
                 'description' => 'Mock Job',
                 'scheduled_date' => '2025-08-07',
                 'scheduled_time' => '09:00:00',
-                'status' => 'Unassigned',
+                'status' => 'scheduled',
                 'duration_minutes' => 60,
                 'customer_id' => 10,
                 'first_name' => 'Jane',
@@ -33,7 +33,7 @@ class JobTest extends TestCase
         $mockPdo->method('prepare')->willReturn($mockStmt);
 
         // Step 3: Run the test
-        $results = Job::getFiltered($mockPdo, 'Unassigned');
+        $results = Job::getFiltered($mockPdo, 'scheduled');
 
         // Step 4: Assert the mock data is returned correctly
         $this->assertCount(1, $results);

--- a/tests/JobsTableEdgeCasesTest.php
+++ b/tests/JobsTableEdgeCasesTest.php
@@ -55,7 +55,7 @@ final class JobsTableEdgeCasesTest extends TestCase
         TestDataFactory::createJob($this->pdo, [
             'customer_id'      => $cid,
             'description'      => 'Hello <script>alert(1)</script>',
-            'status'           => 'Unassigned',
+            'status'           => 'scheduled',
             'scheduled_date'   => (new DateTimeImmutable('+1 day'))->format('Y-m-d'),
             'scheduled_time'   => '09:00:00',
             'duration_minutes' => 30,
@@ -81,7 +81,7 @@ final class JobsTableEdgeCasesTest extends TestCase
         TestDataFactory::createJob($this->pdo, [
             'customer_id'      => $cid,
             'description'      => 'Today job',
-            'status'           => 'Unassigned',
+            'status'           => 'scheduled',
             'scheduled_date'   => (new DateTimeImmutable('today'))->format('Y-m-d'),
             'scheduled_time'   => '10:00:00',
             'duration_minutes' => 30,
@@ -91,7 +91,7 @@ final class JobsTableEdgeCasesTest extends TestCase
         TestDataFactory::createJob($this->pdo, [
             'customer_id'      => $cid,
             'description'      => 'Far future job',
-            'status'           => 'Unassigned',
+            'status'           => 'scheduled',
             'scheduled_date'   => (new DateTimeImmutable('+400 days'))->format('Y-m-d'),
             'scheduled_time'   => '10:00:00',
             'duration_minutes' => 30,
@@ -120,7 +120,7 @@ final class JobsTableEdgeCasesTest extends TestCase
         TestDataFactory::createJob($this->pdo, [
             'customer_id'      => $cid,
             'description'      => 'Wash 100% exterior',
-            'status'           => 'Unassigned',
+            'status'           => 'scheduled',
             'scheduled_date'   => (new DateTimeImmutable('+2 days'))->format('Y-m-d'),
             'scheduled_time'   => '11:00:00',
             'duration_minutes' => 60,
@@ -129,7 +129,7 @@ final class JobsTableEdgeCasesTest extends TestCase
         TestDataFactory::createJob($this->pdo, [
             'customer_id'      => $cid,
             'description'      => 'Underscore_name_job',
-            'status'           => 'Unassigned',
+            'status'           => 'scheduled',
             'scheduled_date'   => (new DateTimeImmutable('+2 days'))->format('Y-m-d'),
             'scheduled_time'   => '12:00:00',
             'duration_minutes' => 60,

--- a/tests/JobsTest.php
+++ b/tests/JobsTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
  * JobsTest — exercises the server-rendered table partial (jobs_table.php)
  * Covers:
  *  - includes created job row
- *  - status filter = Unassigned
+ *  - status filter = scheduled
  *  - description search
  *  - customer-name search
  *  - days range window
@@ -44,7 +44,7 @@ final class JobsTest extends TestCase
     {
         $cid  = TestDataFactory::createCustomer($this->pdo, 'Table', 'Render');
         $date = (new DateTimeImmutable('tomorrow'))->format('Y-m-d');
-        $jobId = TestDataFactory::createJob($this->pdo, $cid, 'Render test row', $date, '09:00:00', 45, 'Unassigned');
+        $jobId = TestDataFactory::createJob($this->pdo, $cid, 'Render test row', $date, '09:00:00', 45, 'scheduled');
 
         $this->pdo->commit();
 
@@ -56,19 +56,19 @@ final class JobsTest extends TestCase
     }
 
     /** @group jobs */
-    public function testStatusFilterUnassigned(): void
+    public function testStatusFilterScheduled(): void
     {
-        $cid  = TestDataFactory::createCustomer($this->pdo, 'Filter', 'Unassigned');
+        $cid  = TestDataFactory::createCustomer($this->pdo, 'Filter', 'Scheduled');
         $date = (new DateTimeImmutable('tomorrow'))->format('Y-m-d');
-        $j1 = TestDataFactory::createJob($this->pdo, $cid, 'Unassigned row', $date, '13:00:00', 30, 'Unassigned');
+        $j1 = TestDataFactory::createJob($this->pdo, $cid, 'scheduled row', $date, '13:00:00', 30, 'scheduled');
         $j2 = TestDataFactory::createJob($this->pdo, $cid, 'Completed row',  $date, '14:00:00', 30, 'Completed');
 
         $this->pdo->commit();
 
-        $html = Http::get('jobs_table.php?status=Unassigned&days=365');
+        $html = Http::get('jobs_table.php?status=scheduled&days=365');
 
         $this->assertNotEmpty($html, 'jobs_table.php (filtered) should return HTML rows');
-        $this->assertStringContainsString((string)$j1, $html, 'Shows Unassigned job');
+        $this->assertStringContainsString((string)$j1, $html, 'Shows scheduled job');
         $this->assertStringNotContainsString((string)$j2, $html, 'Hides Completed job');
     }
 
@@ -81,8 +81,8 @@ final class JobsTest extends TestCase
         $token  = bin2hex(random_bytes(4));
         $needle = "Nebula-$token";
 
-        $matchId    = TestDataFactory::createJob($this->pdo, $cid, "Install $needle Panels", $date, '10:00:00', 45, 'Unassigned');
-        $nonMatchId = TestDataFactory::createJob($this->pdo, $cid, "Routine Maintenance",     $date, '11:00:00', 45, 'Unassigned');
+        $matchId    = TestDataFactory::createJob($this->pdo, $cid, "Install $needle Panels", $date, '10:00:00', 45, 'scheduled');
+        $nonMatchId = TestDataFactory::createJob($this->pdo, $cid, "Routine Maintenance",     $date, '11:00:00', 45, 'scheduled');
 
         $this->pdo->commit();
 
@@ -103,10 +103,10 @@ final class JobsTest extends TestCase
         $date  = (new DateTimeImmutable('tomorrow'))->format('Y-m-d');
 
         $cidMatch   = TestDataFactory::createCustomer($this->pdo, $first, $last);
-        $matchId    = TestDataFactory::createJob($this->pdo, $cidMatch, 'Any description', $date, '10:00:00', 45, 'Unassigned');
+        $matchId    = TestDataFactory::createJob($this->pdo, $cidMatch, 'Any description', $date, '10:00:00', 45, 'scheduled');
 
         $cidOther   = TestDataFactory::createCustomer($this->pdo, 'Comet', 'Customer');
-        $nonMatchId = TestDataFactory::createJob($this->pdo, $cidOther, 'Irrelevant job',  $date, '11:00:00', 45, 'Unassigned');
+        $nonMatchId = TestDataFactory::createJob($this->pdo, $cidOther, 'Irrelevant job',  $date, '11:00:00', 45, 'scheduled');
 
         $this->pdo->commit();
 
@@ -126,8 +126,8 @@ final class JobsTest extends TestCase
         $insideDate  = (new DateTimeImmutable('today +3 days'))->format('Y-m-d');
         $outsideDate = (new DateTimeImmutable('today +30 days'))->format('Y-m-d');
 
-        $insideId  = TestDataFactory::createJob($this->pdo, $cid, 'Inside 7-day window',  $insideDate,  '09:00:00', 60, 'Unassigned');
-        $outsideId = TestDataFactory::createJob($this->pdo, $cid, 'Outside 7-day window', $outsideDate, '09:30:00', 60, 'Unassigned');
+        $insideId  = TestDataFactory::createJob($this->pdo, $cid, 'Inside 7-day window',  $insideDate,  '09:00:00', 60, 'scheduled');
+        $outsideId = TestDataFactory::createJob($this->pdo, $cid, 'Outside 7-day window', $outsideDate, '09:30:00', 60, 'scheduled');
 
         $this->pdo->commit();
 

--- a/tests/assignments/AssignmentsApiNegativeTest.php
+++ b/tests/assignments/AssignmentsApiNegativeTest.php
@@ -45,7 +45,7 @@ final class AssignmentsApiNegativeTest extends TestCase
             $date,
             '10:00:00',
             60,
-            'Unassigned'
+            'scheduled'
         );
 
         $this->employeeId = TestDataFactory::createEmployee($this->pdo, 'Casey', 'Tester');
@@ -152,9 +152,9 @@ final class AssignmentsApiNegativeTest extends TestCase
 
         $stmt = $this->pdo->prepare('SELECT status FROM jobs WHERE id = ?');
         $stmt->execute([$this->jobId]);
-        $this->assertSame('Assigned', (string)$stmt->fetchColumn());
+        $this->assertSame('assigned', (string)$stmt->fetchColumn());
 
-        // Unassign → last assignee removed → flip back to Unassigned
+        // Unassign → last assignee removed → flip back to scheduled
         $unassign = $this->api('unassign', [
             'job_id'      => $this->jobId,
             'employee_id' => $this->employeeId,
@@ -163,6 +163,6 @@ final class AssignmentsApiNegativeTest extends TestCase
         $this->assertTrue($unassign['ok'] ?? false);
 
         $stmt->execute([$this->jobId]);
-        $this->assertSame('Unassigned', (string)$stmt->fetchColumn());
+        $this->assertSame('scheduled', (string)$stmt->fetchColumn());
     }
 }

--- a/tests/jobs/JobsTableEdgeCasesTest.php
+++ b/tests/jobs/JobsTableEdgeCasesTest.php
@@ -55,7 +55,7 @@ final class JobsTableEdgeCasesTest extends TestCase
             $date,
             '09:00:00',
             30,
-            'Unassigned'
+            'scheduled'
         );
 
         $html = $this->renderJobsTable(['days' => 365]);
@@ -72,11 +72,11 @@ final class JobsTableEdgeCasesTest extends TestCase
 
         // Today
         $today = (new DateTimeImmutable('today'))->format('Y-m-d');
-        TestDataFactory::createJob($this->pdo, $cid, 'Today job', $today, '10:00:00', 30, 'Unassigned');
+        TestDataFactory::createJob($this->pdo, $cid, 'Today job', $today, '10:00:00', 30, 'scheduled');
 
         // Far future
         $future = (new DateTimeImmutable('+400 days'))->format('Y-m-d');
-        TestDataFactory::createJob($this->pdo, $cid, 'Far future job', $future, '10:00:00', 30, 'Unassigned');
+        TestDataFactory::createJob($this->pdo, $cid, 'Far future job', $future, '10:00:00', 30, 'scheduled');
 
         // days = 0 -> should not error
         $html0 = $this->renderJobsTable(['days' => 0]);
@@ -96,8 +96,8 @@ final class JobsTableEdgeCasesTest extends TestCase
         $cid = TestDataFactory::createCustomer($this->pdo, 'Alex', 'Percent');
 
         $date = (new DateTimeImmutable('+2 days'))->format('Y-m-d');
-        TestDataFactory::createJob($this->pdo, $cid, 'Wash 100% exterior', $date, '11:00:00', 60, 'Unassigned');
-        TestDataFactory::createJob($this->pdo, $cid, 'Underscore_name_job',  $date, '12:00:00', 60, 'Unassigned');
+        TestDataFactory::createJob($this->pdo, $cid, 'Wash 100% exterior', $date, '11:00:00', 60, 'scheduled');
+        TestDataFactory::createJob($this->pdo, $cid, 'Underscore_name_job',  $date, '12:00:00', 60, 'scheduled');
 
         // Search that includes % sign
         $html1 = $this->renderJobsTable(['search' => '100% exterior', 'days' => 30]);

--- a/tests/rbac/RbacAssignmentsApiV2Test.php
+++ b/tests/rbac/RbacAssignmentsApiV2Test.php
@@ -35,7 +35,7 @@ final class RbacAssignmentsApiV2Test extends TestCase
         $custId       = TestDataFactory::createCustomer($this->pdo, 'RBAC', 'Customer');
         $this->techId = TestDataFactory::createEmployee($this->pdo, 'Felix', 'FieldTech');
         $date         = (new DateTimeImmutable('+1 day'))->format('Y-m-d');
-        $this->jobId  = TestDataFactory::createJob($this->pdo, $custId, 'RBAC v2 job', $date, '10:00:00', 60, 'Unassigned');
+        $this->jobId  = TestDataFactory::createJob($this->pdo, $custId, 'RBAC v2 job', $date, '10:00:00', 60, 'scheduled');
 
         // CSRF (APP_ENV=test) — fetch via test_csrf.php
         $tok         = json_decode(Http::get('test_csrf.php'), true);

--- a/tests/rbac/RbacAssignmentsTest.php
+++ b/tests/rbac/RbacAssignmentsTest.php
@@ -35,7 +35,7 @@ final class RbacAssignmentsTest extends TestCase
         $custId = TestDataFactory::createCustomer($this->pdo, 'RBAC', 'Customer');
         $this->empId = TestDataFactory::createEmployee($this->pdo, 'Rita', 'Role');
         $date = (new DateTimeImmutable('+1 day'))->format('Y-m-d');
-        $this->jobId = TestDataFactory::createJob($this->pdo, $custId, 'RBAC job', $date, '10:00:00', 60, 'Unassigned');
+        $this->jobId = TestDataFactory::createJob($this->pdo, $custId, 'RBAC job', $date, '10:00:00', 60, 'scheduled');
 
         $tok = json_decode(Http::get('test_csrf.php'), true);
         $this->token = (string)($tok['token'] ?? '');

--- a/tests/reset_test_data.php
+++ b/tests/reset_test_data.php
@@ -25,7 +25,7 @@ $pdo->beginTransaction();
 $pdo->exec("DELETE FROM job_employee_assignment");
 
 // Optionally reset job statuses that might have been toggled during tests
-$pdo->exec("UPDATE jobs SET status = 'Unassigned' WHERE id IN (2001,2002,2003)");
+$pdo->exec("UPDATE jobs SET status = 'scheduled' WHERE id IN (2001,2002,2003)");
 
 // (Optional) Re-seed a known assignment if you like:
 // $pdo->exec("INSERT INTO job_employee_assignment (job_id, employee_id) VALUES (2003, 4002)");

--- a/tests/support/TestDataFactory.php
+++ b/tests/support/TestDataFactory.php
@@ -34,7 +34,7 @@ final class TestDataFactory
         $stmt->execute([':e' => $employeeId, ':d' => $dayOfWeek, ':s' => $start, ':t' => $end]);
     }
 
-    public static function createJob(PDO $pdo, int $customerId, string $desc, string $date, string $time, int $duration = 60, string $status = 'Unassigned'): int
+    public static function createJob(PDO $pdo, int $customerId, string $desc, string $date, string $time, int $duration = 60, string $status = 'scheduled'): int
     {
         $stmt = $pdo->prepare("
             INSERT INTO jobs (customer_id, description, status, scheduled_date, scheduled_time, duration_minutes)

--- a/tests/test_no_conflict_eligibility.php
+++ b/tests/test_no_conflict_eligibility.php
@@ -62,7 +62,7 @@ try {
     $stmt->execute([
         ':cid'   => $customerId,
         ':desc'  => 'No-conflict eligibility test job',
-        ':status'=> 'Unassigned',
+        ':status'=> 'scheduled',
         ':sd'    => $tomorrow,
         ':st'    => $jobTime,
         ':dur'   => $duration,


### PR DESCRIPTION
## Summary
- use canonical status list from jobs table throughout forms and helpers
- normalize status values when saving jobs and in API filters
- update tests and scripts for new draft/scheduled/assigned workflow

## Testing
- `make lint` *(fails: Found 77 errors)*
- `make test` *(fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e2b019d10832fac6320df3e7d0c8d