### PR TITLE
Handle invalid JSON in customer search

### DIFF
--- a/public/job_form.php
+++ b/public/job_form.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 require __DIR__ . '/_cli_guard.php';
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/_csrf.php';
@@ -12,7 +14,10 @@ $__csrf    = csrf_token();
 $today     = date('Y-m-d');
 
 /** HTML escape */
-function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
+function s(?string $v): string
+{
+    return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8');
+}
 ?>
 <!doctype html>
 <html lang="en">
@@ -50,7 +55,7 @@ function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES,
       <div class="mb-3">
         <span class="form-label d-block mb-2">Job Types</span>
         <div class="row row-cols-2" id="jobTypes">
-        <?php foreach ($jobTypes as $jt): ?>
+        <?php foreach ($jobTypes as $jt) : ?>
           <div class="col">
             <div class="form-check">
               <input class="form-check-input" type="checkbox" name="job_types[]" value="<?= (int)$jt['id'] ?>" id="jt<?= (int)$jt['id'] ?>">
@@ -87,7 +92,7 @@ function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES,
       <h2 class="h5">Status</h2>
       <div class="mb-3">
         <select name="status" class="form-select" required>
-        <?php foreach ($statuses as $st): ?>
+        <?php foreach ($statuses as $st) : ?>
           <option value="<?= s($st) ?>"<?= $st === 'Scheduled' ? ' selected' : '' ?>><?= s($st) ?></option>
         <?php endforeach; ?>
         </select>
@@ -113,8 +118,19 @@ function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES,
     const q = this.value.trim();
     customerIdInput.value = '';
     if (q.length < 2) { resultsDiv.innerHTML = ''; return; }
-    const resp = await fetch('api/customer_search.php?q=' + encodeURIComponent(q));
-    results = await resp.json();
+    try {
+      const resp = await fetch('api/customer_search.php?q=' + encodeURIComponent(q));
+      if (!resp.ok) throw new Error('Network response was not ok');
+      const contentType = resp.headers.get('content-type') || '';
+      if (!contentType.includes('application/json')) {
+        throw new Error('Invalid JSON');
+      }
+      results = await resp.json();
+    } catch (err) {
+      console.error('Failed to load customer search results', err);
+      results = [];
+    }
+
     resultsDiv.innerHTML = '';
     activeIndex = -1;
     results.forEach((c, idx) => {


### PR DESCRIPTION
## Summary
- handle failed JSON responses when searching for customers on job form

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused)*
- `vendor/bin/phpcs public/job_form.php`


------
https://chatgpt.com/codex/tasks/task_e_689e2811d81c832f9cec617f27059762