### PR TITLE
Fix employee save to use job type IDs

### DIFF
--- a/public/employee_save.php
+++ b/public/employee_save.php
@@ -95,13 +95,14 @@ if ($roleId !== null) {
         $errors[] = 'Role invalid.';
     }
 }
-// Validate skills ids
+// Validate skills ids (job types)
 $skillIds = [];
 if (is_array($skills) && count($skills) > 0) {
     $skills = array_map('intval', $skills);
     $placeholders = implode(',', array_fill(0, count($skills), '?'));
     try {
-        $st = $pdo->prepare('SELECT id FROM skills WHERE id IN (' . $placeholders . ')');
+        // job types are used as skills
+        $st = $pdo->prepare('SELECT id FROM job_types WHERE id IN (' . $placeholders . ')');
         $st->execute($skills);
         $skillIds = array_map('intval', $st->fetchAll(PDO::FETCH_COLUMN));
     } catch (Throwable $e) {
@@ -151,7 +152,8 @@ try {
 
         $pdo->prepare('DELETE FROM employee_skills WHERE employee_id = :eid')->execute([':eid'=>$id]);
         if (!empty($skills)) {
-            $ins = $pdo->prepare('INSERT INTO employee_skills (employee_id, skill_id) VALUES (:eid,:sid)');
+            // employee_skills references job_type_id
+            $ins = $pdo->prepare('INSERT INTO employee_skills (employee_id, job_type_id) VALUES (:eid,:sid)');
             foreach ($skills as $sid) {
                 $ins->execute([':eid'=>$id, ':sid'=>$sid]);
             }
@@ -180,7 +182,8 @@ try {
         $newId = (int)$pdo->lastInsertId();
 
         if (!empty($skills)) {
-            $ins = $pdo->prepare('INSERT INTO employee_skills (employee_id, skill_id) VALUES (:eid,:sid)');
+            // employee_skills references job_type_id
+            $ins = $pdo->prepare('INSERT INTO employee_skills (employee_id, job_type_id) VALUES (:eid,:sid)');
             foreach ($skills as $sid) {
                 $ins->execute([':eid'=>$newId, ':sid'=>$sid]);
             }


### PR DESCRIPTION
## Summary
- ensure employee save validates skills against `job_types`
- store selected skills using `job_type_id`

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e5bca3a18832fa356ac57cb0b9e3a