### PR TITLE
Add sorting to customers page

### DIFF
--- a/models/CustomerDataProvider.php
+++ b/models/CustomerDataProvider.php
@@ -22,7 +22,9 @@ final class CustomerDataProvider
         ?string $search = null,
         ?string $city = null,
         ?string $state = null,
-        ?string $limit = null
+        ?string $limit = null,
+        ?string $sort = 'id',
+        string $order = 'asc'
     ): array {
         $sql = "SELECT id, first_name, last_name, email, phone, address_line1, city, state
                 FROM customers
@@ -46,6 +48,24 @@ final class CustomerDataProvider
         if ($state !== null && $state !== '') {
             $sql .= " AND state = :state";
             $params[':state'] = $state;
+        }
+
+        // Determine sort column and direction
+        $allowedSorts = [
+            'id'    => 'id',
+            'email' => 'email',
+            'phone' => 'phone',
+            'city'  => 'city',
+            'state' => 'state',
+        ];
+        $sort = strtolower((string)$sort);
+        $order = strtolower($order) === 'desc' ? 'DESC' : 'ASC';
+        if ($sort === 'name') {
+            $sql .= ' ORDER BY last_name ' . $order . ', first_name ' . $order;
+        } elseif (isset($allowedSorts[$sort])) {
+            $sql .= ' ORDER BY ' . $allowedSorts[$sort] . ' ' . $order;
+        } else {
+            $sql .= ' ORDER BY id ASC';
         }
 
         // Sanitize limit from string → int

--- a/public/customers.php
+++ b/public/customers.php
@@ -20,7 +20,23 @@ $city  = isset($_GET['city']) ? (string)$_GET['city'] : null;
 $state = isset($_GET['state']) ? (string)$_GET['state'] : null;
 $limit = isset($_GET['limit']) ? (string)$_GET['limit'] : null;
 
-$rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit);
+$sort = isset($_GET['sort']) ? (string)$_GET['sort'] : 'id';
+$dir  = isset($_GET['dir']) && strtolower((string)$_GET['dir']) === 'desc' ? 'desc' : 'asc';
+
+$baseParams = ['q' => $q, 'city' => $city, 'state' => $state, 'limit' => $limit];
+
+/** Build sortable link */
+function sort_link(string $label, string $column, array $params, string $sort, string $dir): string {
+    $nextDir = ($sort === $column && $dir === 'asc') ? 'desc' : 'asc';
+    $query   = array_merge($params, ['sort' => $column, 'dir' => $nextDir]);
+    $qs      = http_build_query(array_filter($query, fn($v) => $v !== null && $v !== ''));
+    $arrow   = '';
+    if ($sort === $column) {
+        $arrow = $dir === 'asc' ? ' ▲' : ' ▼';
+    }
+    return '<a href="/customers.php?' . s($qs) . '">' . s($label) . $arrow . '</a>';
+}
+$rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort, $dir);
 ?>
 <!doctype html>
 <html lang="en">
@@ -46,12 +62,12 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit);
       <table class="table table-striped table-hover m-0">
         <thead class="table-light">
           <tr>
-            <th>ID</th>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Phone</th>
-            <th>City</th>
-            <th>State</th>
+            <th><?= sort_link('ID', 'id', $baseParams, $sort, $dir) ?></th>
+            <th><?= sort_link('Name', 'name', $baseParams, $sort, $dir) ?></th>
+            <th><?= sort_link('Email', 'email', $baseParams, $sort, $dir) ?></th>
+            <th><?= sort_link('Phone', 'phone', $baseParams, $sort, $dir) ?></th>
+            <th><?= sort_link('City', 'city', $baseParams, $sort, $dir) ?></th>
+            <th><?= sort_link('State', 'state', $baseParams, $sort, $dir) ?></th>
             <th>Short Address</th>
             <th class="text-end">Actions</th>
           </tr>

--- a/tests/Unit/CustomerDataProviderSortTest.php
+++ b/tests/Unit/CustomerDataProviderSortTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../models/CustomerDataProvider.php';
+
+final class CustomerDataProviderSortTest extends TestCase
+{
+    public function testSortsByNameAscendingAndDescending(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE customers (
+            id INTEGER PRIMARY KEY,
+            first_name TEXT,
+            last_name TEXT,
+            email TEXT,
+            phone TEXT,
+            address_line1 TEXT,
+            city TEXT,
+            state TEXT
+        )');
+        $pdo->exec("INSERT INTO customers (id, first_name, last_name) VALUES
+            (1,'John','Zulu'),
+            (2,'Jane','Alpha'),
+            (3,'Bob','Mike')");
+
+        $rowsAsc = CustomerDataProvider::getFiltered($pdo, null, null, null, null, 'name', 'asc');
+        $lastAsc = array_column($rowsAsc, 'last_name');
+        $this->assertSame(['Alpha', 'Mike', 'Zulu'], $lastAsc);
+
+        $rowsDesc = CustomerDataProvider::getFiltered($pdo, null, null, null, null, 'name', 'desc');
+        $lastDesc = array_column($rowsDesc, 'last_name');
+        $this->assertSame(['Zulu', 'Mike', 'Alpha'], $lastDesc);
+    }
+}


### PR DESCRIPTION
## Summary
- allow server-side sorting of customers by various fields
- make customer list headers clickable to toggle sort order
- cover sorting behavior with unit tests

## Testing
- `vendor/bin/phpunit tests/Unit/CustomerDataProviderSortTest.php --testdox`
- `make test` *(fails: PDOException: DB connection failed)*
- `make lint` *(fails: Found 81 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e5fc8bc08832fb12d5411756732c9