### PR TITLE
Enable Google Maps autocomplete for employee form

### DIFF
--- a/public/edit_employee.php
+++ b/public/edit_employee.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/../models/JobType.php';
 require_once __DIR__ . '/../models/Role.php';
 require_once __DIR__ . '/_csrf.php';
+require_once __DIR__ . '/../config/api_keys.php';
 
 $pdo   = getPDO();
 $__csrf = csrf_token();
@@ -89,23 +90,23 @@ function stickyArr(string $name, array $default = []): array {
       <fieldset>
         <legend>Contact &amp; Address</legend>
         <label>Address Line 1
-          <input type="text" name="address_line1" value="<?= s(sticky('address_line1', $employee['address_line1'] ?? '')) ?>" required>
+          <input type="text" id="address_line1" name="address_line1" value="<?= s(sticky('address_line1', $employee['address_line1'] ?? '')) ?>" required>
         </label>
         <label>Address Line 2
-          <input type="text" name="address_line2" value="<?= s(sticky('address_line2', $employee['address_line2'] ?? '')) ?>">
+          <input type="text" id="address_line2" name="address_line2" value="<?= s(sticky('address_line2', $employee['address_line2'] ?? '')) ?>">
         </label>
         <label>City
-          <input type="text" name="city" value="<?= s(sticky('city', $employee['city'] ?? '')) ?>" required>
+          <input type="text" id="city" name="city" value="<?= s(sticky('city', $employee['city'] ?? '')) ?>" required>
         </label>
         <label>State
-          <input type="text" name="state" value="<?= s(sticky('state', $employee['state'] ?? '')) ?>" required>
+          <input type="text" id="state" name="state" value="<?= s(sticky('state', $employee['state'] ?? '')) ?>" required>
         </label>
         <label>Postal Code
-          <input type="text" name="postal_code" value="<?= s(sticky('postal_code', $employee['postal_code'] ?? '')) ?>" required>
+          <input type="text" id="postal_code" name="postal_code" value="<?= s(sticky('postal_code', $employee['postal_code'] ?? '')) ?>" required>
         </label>
-        <input type="hidden" name="home_address_lat" value="<?= s(sticky('home_address_lat', isset($employee['latitude']) ? (string)$employee['latitude'] : '')) ?>">
-        <input type="hidden" name="home_address_lon" value="<?= s(sticky('home_address_lon', isset($employee['longitude']) ? (string)$employee['longitude'] : '')) ?>">
-        <input type="hidden" name="google_place_id" value="<?= s(sticky('google_place_id', $employee['google_place_id'] ?? '')) ?>">
+        <input type="hidden" id="home_address_lat" name="home_address_lat" value="<?= s(sticky('home_address_lat', isset($employee['latitude']) ? (string)$employee['latitude'] : '')) ?>">
+        <input type="hidden" id="home_address_lon" name="home_address_lon" value="<?= s(sticky('home_address_lon', isset($employee['longitude']) ? (string)$employee['longitude'] : '')) ?>">
+        <input type="hidden" id="google_place_id" name="google_place_id" value="<?= s(sticky('google_place_id', $employee['google_place_id'] ?? '')) ?>">
       </fieldset>
 
       <fieldset>
@@ -157,5 +158,15 @@ function stickyArr(string $name, array $default = []): array {
       <button type="button" onclick="window.location.href='employees.php'">Cancel</button>
     </form>
   <?php endif; ?>
+  <script src="https://maps.googleapis.com/maps/api/js?key=<?= htmlspecialchars(MAPS_API_KEY, ENT_QUOTES, 'UTF-8') ?>&libraries=places"></script>
+  <script src="js/google_address_autocomplete.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function () {
+      initializeAddressAutocomplete('address_line1', {
+          latitude: 'home_address_lat',
+          longitude: 'home_address_lon'
+      });
+  });
+  </script>
 </body>
 </html>

--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/../models/JobType.php';
 require_once __DIR__ . '/../models/Role.php';
 require_once __DIR__ . '/_csrf.php';
+require_once __DIR__ . '/../config/api_keys.php';
 
 $pdo   = getPDO();
 $__csrf = csrf_token();
@@ -62,23 +63,23 @@ function stickyArr(string $name): array {
     <fieldset>
       <legend>Contact &amp; Address</legend>
       <label>Address Line 1
-        <input type="text" name="address_line1" value="<?= s(sticky('address_line1')) ?>" required>
+        <input type="text" id="address_line1" name="address_line1" value="<?= s(sticky('address_line1')) ?>" required>
       </label>
       <label>Address Line 2
-        <input type="text" name="address_line2" value="<?= s(sticky('address_line2')) ?>">
+        <input type="text" id="address_line2" name="address_line2" value="<?= s(sticky('address_line2')) ?>">
       </label>
       <label>City
-        <input type="text" name="city" value="<?= s(sticky('city')) ?>" required>
+        <input type="text" id="city" name="city" value="<?= s(sticky('city')) ?>" required>
       </label>
       <label>State
-        <input type="text" name="state" value="<?= s(sticky('state')) ?>" required>
+        <input type="text" id="state" name="state" value="<?= s(sticky('state')) ?>" required>
       </label>
       <label>Postal Code
-        <input type="text" name="postal_code" value="<?= s(sticky('postal_code')) ?>" required>
+        <input type="text" id="postal_code" name="postal_code" value="<?= s(sticky('postal_code')) ?>" required>
       </label>
-      <input type="hidden" name="home_address_lat" value="<?= s(sticky('home_address_lat')) ?>">
-      <input type="hidden" name="home_address_lon" value="<?= s(sticky('home_address_lon')) ?>">
-      <input type="hidden" name="google_place_id" value="<?= s(sticky('google_place_id')) ?>">
+      <input type="hidden" id="home_address_lat" name="home_address_lat" value="<?= s(sticky('home_address_lat')) ?>">
+      <input type="hidden" id="home_address_lon" name="home_address_lon" value="<?= s(sticky('home_address_lon')) ?>">
+      <input type="hidden" id="google_place_id" name="google_place_id" value="<?= s(sticky('google_place_id')) ?>">
     </fieldset>
 
     <fieldset>
@@ -129,5 +130,15 @@ function stickyArr(string $name): array {
     <button type="submit">Save Employee</button>
     <button type="button" onclick="window.location.href='employees.php'">Cancel</button>
   </form>
+  <script src="https://maps.googleapis.com/maps/api/js?key=<?= htmlspecialchars(MAPS_API_KEY, ENT_QUOTES, 'UTF-8') ?>&libraries=places"></script>
+  <script src="js/google_address_autocomplete.js"></script>
+  <script>
+  document.addEventListener('DOMContentLoaded', function () {
+      initializeAddressAutocomplete('address_line1', {
+          latitude: 'home_address_lat',
+          longitude: 'home_address_lon'
+      });
+  });
+  </script>
 </body>
 </html>

--- a/public/js/google_address_autocomplete.js
+++ b/public/js/google_address_autocomplete.js
@@ -29,7 +29,8 @@ function initializeAddressAutocomplete(inputId, fieldMap = {}) {
         });
 
         const assign = (id, value) => {
-            const field = document.getElementById(fieldMap[id]);
+            const targetId = fieldMap[id] || id;
+            const field = document.getElementById(targetId);
             if (field) field.value = value || '';
         };
 


### PR DESCRIPTION
## Summary
- load Google Maps API and address autocomplete on employee add/edit forms
- capture and submit latitude/longitude with employee addresses
- fallback to field IDs in address autocomplete script

## Testing
- `php -l public/employee_form.php`
- `php -l public/edit_employee.php`
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e63fa4088832fa12fe4d1aa7b0369