### PR TITLE
Handle GET on employee save endpoint

### DIFF
--- a/public/employee_save.php
+++ b/public/employee_save.php
@@ -35,11 +35,14 @@ register_shutdown_function(function () use ($log): void {
     }
 });
 
-$pdo = getPDO();
-
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 $log('entry method=' . $method);
-if ($method !== 'POST') { $log('Invalid method'); json_out(['ok'=>false,'error'=>'Method not allowed'], 405); }
+if ($method !== 'POST') {
+    $log('Invalid method; redirecting to employee_form.php');
+    redirect_to('employee_form.php');
+}
+
+$pdo = getPDO();
 
 $token = (string)($_POST['csrf_token'] ?? '');
 if (!csrf_verify($token)) { $log('Invalid CSRF token'); json_out(['ok'=>false,'error'=>'Invalid CSRF token'], 422); }

--- a/tests/employees/EmployeeSaveGetRedirectTest.php
+++ b/tests/employees/EmployeeSaveGetRedirectTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../support/Http.php';
+
+#[Group('employees')]
+final class EmployeeSaveGetRedirectTest extends TestCase
+{
+    public function testGetRedirectsToForm(): void
+    {
+        $url = Http::baseUrl() . '/employee_save.php';
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_HEADER => true,
+            CURLOPT_NOBODY => true,
+        ]);
+        $resp = curl_exec($ch);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $this->assertSame(302, $status, "GET should redirect to form, got {$status}.");
+        $this->assertMatchesRegularExpression('/Location: .*employee_form\\.php/i', (string)$resp);
+    }
+}


### PR DESCRIPTION
## Summary
- Redirect non-POST requests on `employee_save.php` to the employee form before touching the database
- Add regression test covering the GET redirect behaviour

## Testing
- `vendor/bin/phpunit tests/employees/EmployeeSaveGetRedirectTest.php`
- `vendor/bin/phpunit tests/employees/EmployeesSaveControllerTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e8fd8df84832f8924a911ad70d799