### PR TITLE
Fix employee skill retrieval to use job type IDs

### DIFF
--- a/public/edit_employee.php
+++ b/public/edit_employee.php
@@ -28,7 +28,8 @@ if ($id > 0) {
         $st->execute([':id' => $id]);
         $employee = $st->fetch(PDO::FETCH_ASSOC) ?: null;
         if ($employee) {
-            $st2 = $pdo->prepare('SELECT skill_id FROM employee_skills WHERE employee_id = :id');
+            // employee_skills stores job_type_id; fetch those ids for the form
+            $st2 = $pdo->prepare('SELECT job_type_id FROM employee_skills WHERE employee_id = :id');
             if ($st2) {
                 $st2->execute([':id' => $id]);
                 $skillIds = array_map('strval', $st2->fetchAll(PDO::FETCH_COLUMN));


### PR DESCRIPTION
## Summary
- Load employee skills using `job_type_id` to match the employee_skills schema

## Testing
- `make test` *(fails: DB connection refused during integration tests)*
- `php -r 'require "config/database.php"; try { $pdo = getPDO(); $rows = $pdo->query("SELECT id FROM job_types")->fetchAll(PDO::FETCH_COLUMN); var_export($rows); } catch (Throwable $e) { echo "ERROR: " . $e->getMessage(); }'` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689e8816a5ac832fbb6f11283dda0197