### PR TITLE
Use job_skills when rendering jobs

### DIFF
--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -59,8 +59,9 @@
         tr.appendChild(custCell);
         // Job skills
         const jsCell=document.createElement('td');
-        if(job.job_skills?.length){
-          jsCell.innerHTML=job.job_skills.map(s=>`<span class="badge bg-secondary-subtle text-secondary border me-1">${h(s.name)}</span>`).join('');
+        const skills = job.job_skills?.length ? job.job_skills : job.job_types;
+        if(skills?.length){
+          jsCell.innerHTML=skills.map(s=>`<span class="badge bg-secondary-subtle text-secondary border me-1">${h(s.name)}</span>`).join('');
         } else {
           jsCell.textContent='—';
         }


### PR DESCRIPTION
## Summary
- Render job skills from `job.job_skills`, falling back to `job.job_types` for backward compatibility

## Testing
- `make test` *(fails: DB connection failed - SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f13f9cd08832f95ad0877b6e55086