### PR TITLE
Remove job_job_types remnants

### DIFF
--- a/bin/cleanup_orphans.php
+++ b/bin/cleanup_orphans.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
  * bin/cleanup_orphans.php
  * Dev-only utility to remove rows that would block FK creation.
  * - Deletes employee_skills rows whose employee/job_type no longer exist
- * - Deletes job_job_types rows whose job/job_type no longer exist
  * - Deletes job_employee_assignment rows whose job/employee no longer exist
  *
  * Idempotent. Prints counts removed.
@@ -40,25 +39,7 @@ try {
     ");
     out("[OK] employee_skills deleted (no job_type): " . (int)$n2);
 
-    // 3) job_job_types → jobs
-    $n3 = $pdo->exec("
-        DELETE jj
-        FROM job_job_types jj
-        LEFT JOIN jobs j ON j.id = jj.job_id
-        WHERE j.id IS NULL
-    ");
-    out("[OK] job_job_types deleted (no job): " . (int)$n3);
-
-    // 4) job_job_types → job_types
-    $n4 = $pdo->exec("
-        DELETE jj
-        FROM job_job_types jj
-        LEFT JOIN job_types t ON t.id = jj.job_type_id
-        WHERE t.id IS NULL
-    ");
-    out("[OK] job_job_types deleted (no job_type): " . (int)$n4);
-
-    // 5) job_employee_assignment → jobs
+    // 3) job_employee_assignment → jobs
     $n5 = $pdo->exec("
         DELETE a
         FROM job_employee_assignment a
@@ -67,7 +48,7 @@ try {
     ");
     out("[OK] job_employee_assignment deleted (no job): " . (int)$n5);
 
-    // 6) job_employee_assignment → employees
+    // 4) job_employee_assignment → employees
     $n6 = $pdo->exec("
         DELETE a
         FROM job_employee_assignment a

--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -209,8 +209,6 @@ ensureFk($pdo, 'employee_skills', 'job_type_id', 'job_types', 'id', 'fk_skills_j
 ensureFk($pdo, 'job_employee_assignment', 'job_id', 'jobs', 'id', 'fk_jea_job', 'CASCADE', 'RESTRICT');
 ensureFk($pdo, 'job_employee_assignment', 'employee_id', 'employees', 'id', 'fk_jea_employee', 'RESTRICT', 'RESTRICT');
 
-ensureFk($pdo, 'job_job_types', 'job_id', 'jobs', 'id', 'fk_jjt_job', 'CASCADE', 'RESTRICT');
-ensureFk($pdo, 'job_job_types', 'job_type_id', 'job_types', 'id', 'fk_jjt_jobtype', 'RESTRICT', 'RESTRICT');
 ensureFk($pdo, 'employee_availability_overrides', 'employee_id', 'employees', 'id', 'fk_eao_employee', 'CASCADE', 'CASCADE');
 
 out(PHP_EOL . "== Ensuring UNIQUE indexes ==");

--- a/bin/schema_check.php
+++ b/bin/schema_check.php
@@ -120,7 +120,6 @@ $required = [
   'customers' => ['id','first_name','last_name'],
   'jobs' => ['id','customer_id','description','status','scheduled_date','scheduled_time','duration_minutes'],
   'job_types' => ['id','name'],
-  'job_job_types' => ['job_id','job_type_id'],
   'employee_skills' => ['employee_id','job_type_id'],
   'employee_availability' => ['id','employee_id','day_of_week','start_time','end_time'],
   'job_employee_assignment' => ['id','job_id','employee_id','assigned_at'],
@@ -153,10 +152,6 @@ $fkExpect = [
   'job_employee_assignment' => [
       ['cols'=>['job_id'],'ref'=>'jobs','refcols'=>['id']],
       ['cols'=>['employee_id'],'ref'=>'employees','refcols'=>['id']],
-  ],
-  'job_job_types' => [
-      ['cols'=>['job_id'],'ref'=>'jobs','refcols'=>['id']],
-      ['cols'=>['job_type_id'],'ref'=>'job_types','refcols'=>['id']],
   ],
 ];
 foreach ($fkExpect as $t=>$list) {

--- a/models/AssignmentEngine.php
+++ b/models/AssignmentEngine.php
@@ -33,10 +33,8 @@ class AssignmentEngine
         $startTs = strtotime($date . ' ' . $time);
         $endTs   = $startTs + ($duration * 60);
 
-        // Required job types
-        $reqTypesStmt = $this->pdo->prepare("SELECT job_type_id FROM job_job_types WHERE job_id = :jid");
-        $reqTypesStmt->execute([':jid' => $jobId]);
-        $reqTypes = array_map('intval', array_column($reqTypesStmt->fetchAll(PDO::FETCH_ASSOC), 'job_type_id'));
+        // Required job types removed with dropped table
+        $reqTypes = [];
 
         // Candidates: active techs
         $candSql = "SELECT e.id AS employee_id, p.first_name, p.last_name, p.latitude AS emp_lat, p.longitude AS emp_lng

--- a/models/JobDataProvider.php
+++ b/models/JobDataProvider.php
@@ -56,10 +56,6 @@ class JobDataProvider
             $where[] = 'j.status = :status';
             $params[':status'] = $status;
         }
-        if ($jobType !== null) {
-            $where[] = 'EXISTS (SELECT 1 FROM job_job_types jjt WHERE jjt.job_id = j.id AND jjt.job_type_id = :jt)';
-            $params[':jt'] = $jobType;
-        }
         if ($search !== null && $search !== '') {
             $where[] = '(j.description LIKE :q OR c.first_name LIKE :q OR c.last_name LIKE :q)';
             $params[':q'] = '%' . $search . '%';

--- a/public/api/assignments/eligible.php
+++ b/public/api/assignments/eligible.php
@@ -73,7 +73,6 @@ $schema = [
   'employee_availability_overrides' => tableExists($pdo, 'employee_availability_overrides'),
   'employee_skills'         => tableExists($pdo,'employee_skills'),
   'job_types'               => tableExists($pdo,'job_types'),
-  'job_job_types'           => tableExists($pdo,'job_job_types'),
   'job_employee_assignment' => tableExists($pdo,'job_employee_assignment'),
   'job_employee'            => tableExists($pdo,'job_employee'),
 ];
@@ -121,20 +120,8 @@ $dtUtc       = (clone $dtLocal)->setTimezone(new DateTimeZone('UTC'));
 $dtUtcEnd    = (clone $dtLocalEnd)->setTimezone(new DateTimeZone('UTC'));
 $jobWindowLabel = sprintf('%s, %s—%s', $dtLocal->format('Y-m-d'), $dtLocal->format('H:i'), $dtLocalEnd->format('H:i'));
 
-/* -------------- Required job types (optional) -------------- */
+/* -------------- Required job types removed -------------- */
 $reqIds = []; $reqNamesById = [];
-if ($schema['job_job_types'] && $schema['job_types']) {
-  $st = $pdo->prepare("
-    SELECT jt.id, jt.name
-    FROM job_job_types jjt
-    JOIN job_types jt ON jt.id = jjt.job_type_id
-    WHERE jjt.job_id = :jobId
-  ");
-  $st->execute([':jobId'=>$jobId]);
-  while ($r = $st->fetch(PDO::FETCH_ASSOC)) {
-    $rid = (int)$r['id']; $reqIds[] = $rid; $reqNamesById[$rid] = (string)$r['name'];
-  }
-}
 
 /* -------------- Helpers -------------- */
 function haversineKm(?float $lat1, ?float $lon1, ?float $lat2, ?float $lon2): ?float {

--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -37,8 +37,6 @@ try {
         $mappedStatuses = ['scheduled', 'assigned', 'in_progress'];
     }
 
-    $jobTypeParam = $_GET['job_type'] ?? '';
-    $jobTypeIds = array_values(array_filter(array_map('intval', explode(',', $jobTypeParam))));
     $search = trim($_GET['search'] ?? '');
 
     $where = ['j.scheduled_date BETWEEN :start AND :end'];
@@ -54,15 +52,6 @@ try {
         $where[] = 'j.status IN (' . implode(',', $ph) . ')';
     }
 
-    if ($jobTypeIds) {
-        $ph = [];
-        foreach ($jobTypeIds as $i => $jt) {
-            $key = ':jt' . $i;
-            $ph[] = $key;
-            $args[$key] = $jt;
-        }
-        $where[] = 'EXISTS (SELECT 1 FROM job_job_types jj WHERE jj.job_id = j.id AND jj.job_type_id IN (' . implode(',', $ph) . '))';
-    }
 
     if ($search !== '') {
         $needle = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $search);

--- a/public/assignments_table.php
+++ b/public/assignments_table.php
@@ -25,12 +25,9 @@ SELECT
   c.last_name  AS cust_last,
   CONCAT(c.address_line1, ' ', COALESCE(c.city,''), ' ', COALESCE(c.state,'')) AS short_address,
   e.id AS employee_id,
-  CONCAT(p.first_name, ' ', p.last_name) AS employee_name,
-  GROUP_CONCAT(DISTINCT jt.name ORDER BY jt.name SEPARATOR ', ') AS job_types
+  CONCAT(p.first_name, ' ', p.last_name) AS employee_name
 FROM jobs j
 JOIN customers c ON c.id = j.customer_id
-LEFT JOIN job_job_types jjt ON jjt.job_id = j.id
-LEFT JOIN job_types jt ON jt.id = jjt.job_type_id
 LEFT JOIN job_employee_assignment jea ON jea.job_id = j.id
 LEFT JOIN employees e ON e.id = jea.employee_id
 LEFT JOIN people p ON p.id = e.person_id
@@ -90,7 +87,6 @@ foreach ($rows as $r) {
   $cust  = trim(((string)($r['cust_first'] ?? '')) . ' ' . ((string)($r['cust_last'] ?? '')));
   $cust  = htmlspecialchars($cust, ENT_QUOTES, 'UTF-8');
   $addr  = htmlspecialchars((string)($r['short_address'] ?? ''), ENT_QUOTES, 'UTF-8');
-  $types = htmlspecialchars((string)($r['job_types'] ?? ''), ENT_QUOTES, 'UTF-8');
 
   $badgeClass = 'secondary';
   if ($stat === 'scheduled') $badgeClass = 'danger';
@@ -99,7 +95,7 @@ foreach ($rows as $r) {
 
   echo "<tr>";
   echo "  <td class=\"text-nowrap\">#{$jid}</td>";
-  echo "  <td><div class=\"fw-semibold\">{$desc}</div><div class=\"small text-muted\">{$types}</div></td>";
+  echo "  <td><div class=\"fw-semibold\">{$desc}</div></td>";
   echo "  <td><div>{$cust}</div><div class=\"small text-muted\">{$addr}</div></td>";
   echo "  <td class=\"text-nowrap\"><div>{$date}</div><div class=\"small text-muted\">{$time} · {$dur} min</div></td>";
   $label = htmlspecialchars(str_replace('_',' ', $stat), ENT_QUOTES, 'UTF-8');

--- a/public/job_process.php
+++ b/public/job_process.php
@@ -32,7 +32,6 @@ $scheduled_date= trim((string)($_POST['scheduled_date'] ?? ''));
 $scheduled_time= trim((string)($_POST['scheduled_time'] ?? ''));
 $duration_min  = (int)($_POST['duration_minutes'] ?? 0);
 $status        = trim((string)($_POST['status'] ?? ''));
-$job_types     = $_POST['job_types'] ?? [];
 
 $errors = [];
 if ($customer_id <= 0)      $errors[] = 'Customer is required.';
@@ -60,12 +59,7 @@ try {
         ]);
         $jobId = (int)$pdo->lastInsertId();
 
-        if (is_array($job_types) && !empty($job_types)) {
-            $jtIns = $pdo->prepare("INSERT INTO job_job_types (job_id, job_type_id) VALUES (:jid, :jt)");
-            foreach ($job_types as $jt) {
-                $jt = (int)$jt; if ($jt > 0) $jtIns->execute([':jid' => $jobId, ':jt' => $jt]);
-            }
-        }
+        // job types removed
     } else {
         if ($id <= 0) throw new RuntimeException('Missing job ID.');
         $upd = $pdo->prepare("
@@ -79,13 +73,7 @@ try {
             ':dur'=>$duration_min, ':stt'=>$status, ':id'=>$id,
         ]);
 
-        $pdo->prepare("DELETE FROM job_job_types WHERE job_id = :id")->execute([':id'=>$id]);
-        if (is_array($job_types) && !empty($job_types)) {
-            $jtIns = $pdo->prepare("INSERT INTO job_job_types (job_id, job_type_id) VALUES (:jid, :jt)");
-            foreach ($job_types as $jt) {
-                $jt = (int)$jt; if ($jt > 0) $jtIns->execute([':jid'=>$id, ':jt'=>$jt]);
-            }
-        }
+        // job types removed
     }
 
     $pdo->commit();

--- a/tests/Integration/DbSmokeTest.php
+++ b/tests/Integration/DbSmokeTest.php
@@ -29,7 +29,6 @@ final class DbSmokeTest extends TestCase
             'employees',
             'jobs',
             'job_types',
-            'job_job_types',
             'job_employee_assignment',
             'employee_availability',
         ];

--- a/tests/Integration/JobWriteValidationTest.php
+++ b/tests/Integration/JobWriteValidationTest.php
@@ -15,7 +15,6 @@ final class JobWriteValidationTest extends TestCase
         $this->pdo = getPDO();
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-        $this->pdo->exec("DELETE FROM job_job_types");
         $this->pdo->exec("DELETE FROM jobs");
         $this->pdo->exec("DELETE FROM customers");
 

--- a/tests/db_sanity_check.php
+++ b/tests/db_sanity_check.php
@@ -38,7 +38,7 @@ function printSample(PDO $pdo, string $table): void {
 }
 
 // Check key tables
-$tables = ['jobs', 'employees', 'job_employee_assignment', 'customers', 'job_job_types'];
+$tables = ['jobs', 'employees', 'job_employee_assignment', 'customers'];
 foreach ($tables as $table) {
     try {
         printSample($pdo, $table);

--- a/tests/db_sanity_check.php.save
+++ b/tests/db_sanity_check.php.save
@@ -81,7 +81,7 @@ function printSample(PDO $pdo, string $table): void {
 }
 
 // Check key tables
-$tables = ['jobs', 'employees', 'job_employee_assignment', 'customers', 'job_job_types'];
+$tables = ['jobs', 'employees', 'job_employee_assignment', 'customers'];
 foreach ($tables as $table) {
     try {
         printSample($pdo, $table);

--- a/tests/test_no_conflict_eligibility.php
+++ b/tests/test_no_conflict_eligibility.php
@@ -90,9 +90,8 @@ try {
     // Discover if job types are in play via presence of tables
     $hasJobTypes = (bool)$pdo->query("SHOW TABLES LIKE 'job_types'")->fetchColumn();
     $hasEmployeeSkills = (bool)$pdo->query("SHOW TABLES LIKE 'employee_skills'")->fetchColumn();
-    $hasJobJobTypes = (bool)$pdo->query("SHOW TABLES LIKE 'job_job_types'")->fetchColumn();
 
-    if ($hasJobTypes && $hasEmployeeSkills && $hasJobJobTypes) {
+    if ($hasJobTypes && $hasEmployeeSkills) {
         $needTypes = true;
         // Create a job type if none exists
         $typeId = (int)($pdo->query("SELECT id FROM job_types LIMIT 1")->fetchColumn() ?: 0);
@@ -100,10 +99,6 @@ try {
             $pdo->exec("INSERT INTO job_types (name) VALUES ('General')");
             $typeId = (int)$pdo->lastInsertId();
         }
-
-        // Link job to type
-        $stmt = $pdo->prepare("INSERT INTO job_job_types (job_id, job_type_id) VALUES (:j,:t)");
-        $stmt->execute([':j' => $jobId, ':t' => $typeId]);
 
         // Grant employee the skill
         $stmt = $pdo->prepare("INSERT INTO employee_skills (employee_id, job_type_id) VALUES (:e,:t)");


### PR DESCRIPTION
## Summary
- drop job_job_types references from assignment logic, APIs, schema tools, and tests
- keep fieldops SQL dump untouched to preserve seed data

## Testing
- ⚠️ `php bin/schema_check.php` (DB connection failed: SQLSTATE[HY000] [2002] Connection refused)
- ⚠️ `vendor/bin/phpunit` (DB connection failed: SQLSTATE[HY000] [2002] Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_689f2bd64500832fb0afa1ac5f92ec28