### PR TITLE
Improve employee form submission UX

### DIFF
--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -12,6 +12,12 @@
     form.addEventListener('submit', function(e){
       e.preventDefault();
       showErrors([]);
+      var submitBtn = form.querySelector('button[type="submit"]');
+      var originalBtnHTML = submitBtn ? submitBtn.innerHTML : '';
+      if(submitBtn){
+        submitBtn.disabled = true;
+        submitBtn.innerHTML = 'Saving...';
+      }
       var fd = new FormData(form);
       fetch('employee_save.php?json=1', {
         method: 'POST',
@@ -24,6 +30,7 @@
         return resp.json();
       }).then(function(data){
         if(data && data.ok){
+          alert('Employee saved');
           window.location.href = 'employees.php';
           return;
         }
@@ -36,8 +43,15 @@
           errs = ['Unknown error'];
         }
         showErrors(errs);
+        if(errBox) errBox.scrollIntoView({behavior:'smooth'});
       }).catch(function(){
         showErrors(['Request failed. Please try again.']);
+        if(errBox) errBox.scrollIntoView({behavior:'smooth'});
+      }).finally(function(){
+        if(submitBtn){
+          submitBtn.disabled = false;
+          submitBtn.innerHTML = originalBtnHTML;
+        }
       });
     });
   });


### PR DESCRIPTION
## Summary
- Disable employee form submit button and show "Saving..." while request is in progress
- Alert "Employee saved" before redirecting on successful save
- Scroll to error box and re-enable submit button when save fails or completes

## Testing
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e5778b4832fab8ac809a085a3ba