### PR TITLE
Add client-side validation for employee form

### DIFF
--- a/public/css/employee_form.css
+++ b/public/css/employee_form.css
@@ -1,0 +1,9 @@
+input.error, select.error, textarea.error {
+  border: 1px solid red;
+}
+
+.field-error {
+  color: red;
+  font-size: 0.875rem;
+  margin-top: 4px;
+}

--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -25,6 +25,7 @@ $roles = Role::all($pdo);
   <meta charset="utf-8">
   <title>Add Employee</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="css/employee_form.css">
 </head>
 <body>
 <?php

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -9,9 +9,62 @@
       var html = '<ul>' + list.map(function(e){return '<li>'+e+'</li>';}).join('') + '</ul>';
       errBox.innerHTML = html;
     }
+
+    var requiredFields = form.querySelectorAll('[required]');
+
+    function getFieldErrorEl(field){
+      var parent = field.closest('label') || field.parentNode;
+      var err = parent.querySelector('.field-error');
+      if(!err){
+        err = document.createElement('div');
+        err.className = 'field-error';
+        parent.appendChild(err);
+      }
+      return err;
+    }
+
+    function validateField(field){
+      var value = field.value.trim();
+      var message = '';
+      if(!value){
+        message = 'This field is required.';
+      } else if(field.type === 'email'){
+        var emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if(!emailRe.test(value)) message = 'Please enter a valid email.';
+      } else if(field.type === 'tel' && field.pattern){
+        var telRe = new RegExp(field.pattern);
+        if(!telRe.test(value)) message = field.title || 'Please match the requested format.';
+      }
+      var err = getFieldErrorEl(field);
+      if(message){
+        field.classList.add('error');
+        err.textContent = message;
+        return false;
+      }
+      field.classList.remove('error');
+      err.textContent = '';
+      return true;
+    }
+
+    requiredFields.forEach(function(f){
+      ['input','change'].forEach(function(ev){
+        f.addEventListener(ev, function(){ validateField(f); });
+      });
+    });
+
+    function validateForm(){
+      var ok = true;
+      requiredFields.forEach(function(f){ if(!validateField(f)) ok = false; });
+      return ok;
+    }
+
     form.addEventListener('submit', function(e){
       e.preventDefault();
       showErrors([]);
+      if(!validateForm()){
+        showErrors(['Please correct the highlighted fields.']);
+        return;
+      }
       var fd = new FormData(form);
       fetch('employee_save.php?json=1', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- add real-time validation for required employee form fields with inline error messaging
- style invalid fields with red borders and error text
- include employee form stylesheet

## Testing
- `make test` *(integration tests fail: DB connection refused)*
- `make lint` *(PHPStan reports missing symbols and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e52a038832fbb925100313a1dda