### PR TITLE
feat: enhance employee skills selection

### DIFF
--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -25,6 +25,7 @@ $roles = Role::all($pdo);
   <meta charset="utf-8">
   <title>Add Employee</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 </head>
 <body>
 <?php
@@ -119,18 +120,19 @@ function stickyArr(string $name): array {
     <fieldset>
       <legend>Skills</legend>
       <?php $selSkills = stickyArr('skills'); ?>
-      <?php foreach ($skills as $sk): ?>
-        <?php $id = (int)$sk['id']; $name = (string)$sk['name']; ?>
-        <label>
-          <input type="checkbox" name="skills[]" value="<?= $id ?>" <?= in_array((string)$id, $selSkills, true) ? 'checked' : '' ?>>
-          <?= s($name) ?>
-        </label>
-      <?php endforeach; ?>
+      <select id="skills" name="skills[]" multiple="multiple">
+        <?php foreach ($skills as $sk): ?>
+          <?php $id = (int)$sk['id']; $name = (string)$sk['name']; ?>
+          <option value="<?= $id ?>" <?= in_array((string)$id, $selSkills, true) ? 'selected' : '' ?>><?= s($name) ?></option>
+        <?php endforeach; ?>
+      </select>
     </fieldset>
 
     <button type="submit">Save Employee</button>
     <button type="button" onclick="window.location.href='employees.php'">Cancel</button>
   </form>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
   <script src="js/employee_form.js"></script>
   <script src="https://maps.googleapis.com/maps/api/js?key=<?= htmlspecialchars(MAPS_API_KEY, ENT_QUOTES, 'UTF-8') ?>&libraries=places"></script>
   <script src="js/google_address_autocomplete.js"></script>

--- a/public/employee_save.php
+++ b/public/employee_save.php
@@ -72,7 +72,14 @@ $employmentType = trim((string)($_POST['employment_type']   ?? ''));
 $hireDate       = trim((string)($_POST['hire_date']         ?? ''));
 $status         = trim((string)($_POST['status']            ?? ''));
 $roleId         = (string)($_POST['role_id'] ?? '') !== '' ? (int)$_POST['role_id'] : null;
-$skills         = $_POST['skills'] ?? [];
+$skillsInput    = $_POST['skills'] ?? [];
+if (is_string($skillsInput)) {
+    $skills = array_filter(array_map('intval', explode(',', $skillsInput)));
+} elseif (is_array($skillsInput)) {
+    $skills = $skillsInput;
+} else {
+    $skills = [];
+}
 
 $log('Processing id=' . $id);
 

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -1,5 +1,12 @@
 (function(){
   document.addEventListener('DOMContentLoaded', function () {
+    if (window.jQuery && jQuery('#skills').length) {
+      jQuery('#skills').select2({
+        width: '100%',
+        placeholder: 'Select skills'
+      });
+    }
+
     var form = document.getElementById('employeeForm');
     if (!form) return;
     var errBox = document.getElementById('form-errors');


### PR DESCRIPTION
## Summary
- replace employee skill checkboxes with a Select2 multi-select
- load Select2 via CDN and initialize it in the form script
- support parsing multi-select skill values server-side

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f3e5a21a0832fb1cbf3a8068675a9