### PR TITLE
Add phone input masking on employee form

### DIFF
--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -28,6 +28,7 @@ $roles = Role::all($pdo);
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/employee_form.css">
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/inputmask@5/dist/inputmask.min.js"></script>
 </head>
 <body>
 <?php
@@ -67,11 +68,11 @@ function stickyArr(string $name): array {
           </label>
         </div>
         <div class="col-md-6">
-          <label class="form-label">Phone
-            <input type="tel" class="form-control" name="phone" value="<?= s(sticky('phone')) ?>" required pattern="\d{3}[\s-]?\d{3}[\s-]?\d{4}" placeholder="123-456-7890" title="Enter a 10-digit phone number">
-          </label>
-        </div>
-      </fieldset>
+            <label class="form-label">Phone
+              <input type="tel" class="form-control" name="phone" value="<?= s(sticky('phone')) ?>" required pattern="\\(\\d{3}\\) \\d{3}-\\d{4}" placeholder="(123) 456-7890" title="Enter a 10-digit phone number">
+            </label>
+          </div>
+        </fieldset>
 
       <fieldset class="row g-3">
         <legend class="col-12">Contact &amp; Address</legend>

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -2,6 +2,10 @@
   document.addEventListener('DOMContentLoaded', function () {
     var form = document.getElementById('employeeForm');
     if (!form) return;
+    var phoneEl = form.querySelector('input[name="phone"]');
+    if (phoneEl && typeof Inputmask !== 'undefined') {
+      new Inputmask("(999) 999-9999").mask(phoneEl);
+    }
     var errBox = document.getElementById('form-errors');
     function showErrors(list){
       if(!errBox) return;


### PR DESCRIPTION
## Summary
- load Inputmask library on employee form
- apply phone number mask `(999) 999-9999`
- update phone field pattern to match mask

## Testing
- `./vendor/bin/phpunit --testdox` (fails: DB connection refused)
- `./vendor/bin/phpstan analyse --memory-limit=1G` (fails: found 91 errors)


------
https://chatgpt.com/codex/tasks/task_e_689f4ca45e94832f96e05a0a70a5425b