### PR TITLE
Allow flexible spacing in employee phone field

### DIFF
--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -72,7 +72,7 @@ function stickyArr(string $name): array {
         </div>
         <div class="col-md-6">
           <label class="form-label" for="phone">Phone <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="tel" class="form-control" id="phone" name="phone" value="<?= s(sticky('phone')) ?>" required aria-required="true" pattern="\\(\\d{3}\\) \\d{3}-\\d{4}" placeholder="(123) 456-7890" title="Enter a 10-digit phone number">
+          <input type="tel" class="form-control" id="phone" name="phone" value="<?= s(sticky('phone')) ?>" required aria-required="true" pattern="\\(\\d{3}\\)[\\s\\u00A0]\\d{3}-\\d{4}" placeholder="(123) 456-7890" title="Enter a 10-digit phone number">
           <div class="invalid-feedback">Valid phone is required.</div>
         </div>
         </fieldset>


### PR DESCRIPTION
## Summary
- Relax phone input pattern to accept spaces or non-breaking spaces

## Testing
- `php -l public/employee_form.php`
- `vendor/bin/phpunit` *(fails: DB connection refused)*
- `curl -I localhost:8000/employee_form.php` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f5c8bca04832f9c70137dac0b7a19