### PR TITLE
Normalize employee phone numbers

### DIFF
--- a/public/edit_employee.php
+++ b/public/edit_employee.php
@@ -34,6 +34,10 @@ if ($id > 0) {
                 $st2->execute([':id' => $id]);
                 $skillIds = array_map('strval', $st2->fetchAll(PDO::FETCH_COLUMN));
             }
+            $ph = $employee['phone'] ?? '';
+            if (is_string($ph) && preg_match('/^\d{10}$/', $ph)) {
+                $employee['phone'] = sprintf('(%s) %s-%s', substr($ph, 0, 3), substr($ph, 3, 3), substr($ph, 6));
+            }
         }
     }
 }

--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -72,7 +72,7 @@ function stickyArr(string $name): array {
         </div>
         <div class="col-md-6">
           <label class="form-label" for="phone">Phone <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="tel" class="form-control" id="phone" name="phone" value="<?= s(sticky('phone')) ?>" required aria-required="true" pattern="\\(\\d{3}\\) \\d{3}-\\d{4}" placeholder="(123) 456-7890" title="Enter a 10-digit phone number">
+          <input type="tel" class="form-control" id="phone" name="phone" value="<?= s(sticky('phone')) ?>" required aria-required="true" pattern="\\(\\d{3}\\)[\\s\\u00A0]\\d{3}-\\d{4}" placeholder="(123) 456-7890" title="Enter a 10-digit phone number">
           <div class="invalid-feedback">Valid phone is required.</div>
         </div>
         </fieldset>

--- a/public/employee_save.php
+++ b/public/employee_save.php
@@ -55,12 +55,9 @@ $email          = trim((string)($_POST['email']             ?? ''));
 $phoneRaw       = trim((string)($_POST['phone']             ?? ''));
 // Strip all non-digits so we can validate length reliably
 $digits = preg_replace('/\D+/', '', $phoneRaw);
-// Format to (123) 456-7890 when 10 digits supplied; otherwise keep raw for now
-if (is_string($digits) && strlen($digits) === 10) {
-    $phone = sprintf('(%s) %s-%s', substr($digits, 0, 3), substr($digits, 3, 3), substr($digits, 6));
-} else {
-    $phone = $phoneRaw;
-}
+// Store raw digits for consistency across duplicate checks and persistence
+$phone  = is_string($digits) ? $digits : '';
+$log(sprintf('Phone raw input: %s, digits: %s', $phoneRaw, $phone));
 $addr1          = trim((string)($_POST['address_line1']     ?? ''));
 $addr2          = trim((string)($_POST['address_line2']     ?? ''));
 $city           = trim((string)($_POST['city']              ?? ''));
@@ -118,7 +115,7 @@ if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
 if (!is_string($digits) || strlen($digits) !== 10) {
     $addError('Valid phone is required.');
 } else {
-    // $phone already formatted above when 10 digits were supplied
+    // $phone contains only digits for comparison
     $sql = 'SELECT 1 FROM people WHERE phone = :ph';
     $params = [':ph' => $phone];
     if ($personId !== null) {


### PR DESCRIPTION
## Summary
- Store employee phone numbers as unformatted digits and log normalization
- Format stored digits for display in the edit employee form

## Testing
- `php -l public/employee_save.php`
- `php -l public/edit_employee.php`
- `php -l public/employee_form.php`
- `vendor/bin/phpunit` *(fails: DB connection refused)*
- `curl -I localhost:8000/employee_form.php` *(fails: couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689f5c8bca04832f9c70137dac0b7a19