### PR TITLE
Add bulk employee activation controls

### DIFF
--- a/public/employee_bulk_update.php
+++ b/public/employee_bulk_update.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
+
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/_csrf.php';
+
+function json_out(array $payload, int $code = 200): void {
+    http_response_code($code);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($payload, JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    json_out(['ok' => false, 'error' => 'Method not allowed'], 405);
+}
+
+$token = (string)($_POST['csrf_token'] ?? '');
+if (!csrf_verify($token)) {
+    json_out(['ok' => false, 'error' => 'Invalid CSRF token'], 422);
+}
+
+$action = strtolower(trim((string)($_POST['action'] ?? '')));
+$ids = $_POST['ids'] ?? [];
+if (!is_array($ids)) {
+    $ids = [$ids];
+}
+$ids = array_values(array_filter(array_map('intval', $ids), static fn(int $v): bool => $v > 0));
+if ($ids === []) {
+    json_out(['ok' => false, 'error' => 'No IDs provided'], 422);
+}
+
+$isActive = null;
+if ($action === 'activate') {
+    $isActive = 1;
+} elseif ($action === 'deactivate') {
+    $isActive = 0;
+} else {
+    json_out(['ok' => false, 'error' => 'Invalid action'], 422);
+}
+
+try {
+    $pdo = getPDO();
+    $placeholders = implode(',', array_fill(0, count($ids), '?'));
+    $sql = "UPDATE employees SET is_active = ? WHERE id IN ($placeholders)";
+    $params = array_merge([$isActive], $ids);
+    $st = $pdo->prepare($sql);
+    $st->execute($params);
+    json_out(['ok' => true, 'updated' => $st->rowCount()]);
+} catch (Throwable $e) {
+    error_log('[employee_bulk_update] ' . $e->getMessage());
+    json_out(['ok' => false, 'error' => 'Update failed'], 500);
+}

--- a/public/employees.php
+++ b/public/employees.php
@@ -53,6 +53,14 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
   <div class="mb-3">
     <input type="search" id="employee-search" class="form-control form-control-sm" placeholder="Search employees">
   </div>
+  <div class="mb-3 d-flex">
+    <select id="bulk-action" class="form-select form-select-sm w-auto me-2">
+      <option value="">Bulk Actions</option>
+      <option value="activate">Activate</option>
+      <option value="deactivate">Deactivate</option>
+    </select>
+    <button id="bulk-apply" class="btn btn-sm btn-secondary">Apply</button>
+  </div>
   <div class="card">
     <div class="table-responsive">
       <table class="table table-striped table-hover m-0" id="employees-table">
@@ -63,6 +71,7 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
             $activeDir = ($sort === 'is_active' && strtolower((string)$direction) === 'asc') ? 'desc' : 'asc';
           ?>
           <tr>
+            <th><input type="checkbox" id="select-all"></th>
             <th><a href="?perPage=<?= $perPage ?>&sort=employee_id&direction=<?= $idDir ?><?= $skillQuery ?>">ID</a></th>
             <th><a href="?perPage=<?= $perPage ?>&sort=last_name&direction=<?= $nameDir ?><?= $skillQuery ?>">Name</a></th>
             <th>Skills</th>
@@ -72,6 +81,7 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
         <tbody>
         <?php foreach ($rows as $r): ?>
           <tr>
+            <td><input type="checkbox" class="emp-check" value="<?= (int)$r['employee_id'] ?>"></td>
             <td><?= (int)$r['employee_id'] ?></td>
             <td><?= s($r['first_name'] . ' ' . $r['last_name']) ?></td>
             <td><?= s($r['skills']) ?></td>
@@ -122,6 +132,20 @@ $(function(){
     const vals=skillFilter.val()||[];
     vals.forEach(v=>params.append('skills[]',v));
     window.location='?'+params.toString();
+  });
+
+  $('#select-all').on('change',function(){
+    const checked=this.checked;
+    $('.emp-check').prop('checked',checked);
+  });
+
+  $('#bulk-apply').on('click',function(){
+    const action=$('#bulk-action').val();
+    const ids=$('.emp-check:checked').map((_,el)=>el.value).get();
+    if(!action||ids.length===0){return;}
+    $.post('employee_bulk_update.php',{action:action,ids:ids,csrf_token:'<?= $CSRF ?>'},function(res){
+      if(res.ok){location.reload();}else{alert(res.error||'Error');}
+    },'json');
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- enable selecting employees with checkboxes
- add bulk activate/deactivate actions
- support bulk update via new endpoint

## Testing
- `php -l public/employee_bulk_update.php`
- `php -l public/employees.php`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f7449e574832fb460b24a13aedab7