### PR TITLE
Display skill proficiency badges for employees

### DIFF
--- a/models/EmployeeDataProvider.php
+++ b/models/EmployeeDataProvider.php
@@ -10,7 +10,7 @@ final class EmployeeDataProvider
      *   employee_id:int,
      *   first_name:string,
      *   last_name:string,
-     *   skills:string,
+     *   skills:string, // CSV of "skill|proficiency"
      *   is_active:int
      * }>, total:int}
      */
@@ -73,7 +73,13 @@ final class EmployeeDataProvider
             SELECT e.id AS employee_id,
                    p.first_name,
                    p.last_name,
-                   COALESCE(GROUP_CONCAT(DISTINCT jt.name ORDER BY jt.name SEPARATOR ', '), '') AS skills,
+                   COALESCE(
+                       GROUP_CONCAT(
+                           DISTINCT CONCAT(jt.name, '|', COALESCE(es.proficiency, ''))
+                           ORDER BY jt.name SEPARATOR ','
+                       ),
+                       ''
+                   ) AS skills,
                    e.is_active
             FROM employees e
             JOIN people p ON p.id = e.person_id

--- a/public/css/skills.css
+++ b/public/css/skills.css
@@ -1,0 +1,3 @@
+.badge-pressure-washing{background-color:#0d6efd;color:#fff;}
+.badge-window-washing{background-color:#198754;color:#fff;}
+.badge-default-skill{background-color:#6c757d;color:#fff;}


### PR DESCRIPTION
## Summary
- Join `employee_skills` proficiency in employee data provider
- Render employee skills as color-coded badges with proficiency labels
- Add CSS styles for skill badges

## Testing
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f755a2728832fb130ed5ac7a23113