### PR TITLE
Add proficiency column to employee skills schema

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -194,6 +194,18 @@ if (!tableExists($pdo, 'employee_availability_overrides')) {
     out('[OK] employee_availability_overrides created');
 }
 
+// Ensure employee_skills.proficiency column exists
+if (tableExists($pdo, 'employee_skills')) {
+    $cols = columns($pdo, 'employee_skills');
+    if (!array_key_exists('proficiency', $cols)) {
+        out('[..] Adding `proficiency` column to employee_skills ...');
+        $pdo->exec("ALTER TABLE `employee_skills` ADD COLUMN `proficiency` VARCHAR(20) NULL");
+        out('[OK] employee_skills.proficiency added');
+    } else {
+        out('[OK] employee_skills.proficiency present');
+    }
+}
+
 out("== Ensuring PRIMARY KEYS ==");
 foreach (['people','employees','job_types','employee_availability_overrides'] as $t) {
     ensureAutoPk($pdo, $t);

--- a/bin/schema_check.php
+++ b/bin/schema_check.php
@@ -120,7 +120,7 @@ $required = [
   'customers' => ['id','first_name','last_name'],
   'jobs' => ['id','customer_id','description','status','scheduled_date','scheduled_time','duration_minutes'],
   'job_types' => ['id','name'],
-  'employee_skills' => ['employee_id','job_type_id'],
+  'employee_skills' => ['employee_id','job_type_id','proficiency'],
   'employee_availability' => ['id','employee_id','day_of_week','start_time','end_time'],
   'job_employee_assignment' => ['id','job_id','employee_id','assigned_at'],
 ];


### PR DESCRIPTION
## Summary
- ensure `employee_skills.proficiency` column is created if missing
- require `employee_skills.proficiency` in schema checks

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/phpstan analyse --memory-limit=512M`
- `./vendor/bin/phpcs`


------
https://chatgpt.com/codex/tasks/task_e_689f77554d10832f988cd4f6d911a52c