### PR TITLE
Expose employee contact details

### DIFF
--- a/models/EmployeeDataProvider.php
+++ b/models/EmployeeDataProvider.php
@@ -10,6 +10,8 @@ final class EmployeeDataProvider
      *   employee_id:int,
      *   first_name:string,
      *   last_name:string,
+     *   email:?string,
+     *   phone:?string,
      *   skills:string, // CSV of "skill|proficiency"
      *   is_active:int,
      *   status:string
@@ -74,6 +76,8 @@ final class EmployeeDataProvider
             SELECT e.id AS employee_id,
                    p.first_name,
                    p.last_name,
+                   p.email,
+                   p.phone,
                    COALESCE(
                        GROUP_CONCAT(
                            DISTINCT CONCAT(jt.name, '|', COALESCE(es.proficiency, ''))
@@ -88,7 +92,7 @@ final class EmployeeDataProvider
             LEFT JOIN employee_skills es ON es.employee_id = e.id
             LEFT JOIN job_types jt ON jt.id = es.job_type_id
             $where
-            GROUP BY e.id, p.first_name, p.last_name, e.is_active, e.status
+            GROUP BY e.id, p.first_name, p.last_name, p.email, p.phone, e.is_active, e.status
             ORDER BY $orderBy
             LIMIT :limit OFFSET :offset
         ";
@@ -101,7 +105,7 @@ final class EmployeeDataProvider
         $stmt->bindValue(':offset', $offset, \PDO::PARAM_INT);
         $stmt->execute();
 
-        /** @var array<int, array{employee_id:int, first_name:string, last_name:string, skills:string, is_active:int, status:string}> */
+        /** @var array<int, array{employee_id:int, first_name:string, last_name:string, email:?string, phone:?string, skills:string, is_active:int, status:string}> */
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         return ['rows' => $rows, 'total' => $total];
     }

--- a/public/employees.php
+++ b/public/employees.php
@@ -115,8 +115,11 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
             <th><input type="checkbox" id="select-all"></th>
             <th><a href="?perPage=<?= $perPage ?>&sort=employee_id&direction=<?= $idDir ?><?= $skillQuery ?>">ID</a></th>
             <th><a href="?perPage=<?= $perPage ?>&sort=last_name&direction=<?= $nameDir ?><?= $skillQuery ?>">Name</a></th>
+            <th>Email</th>
+            <th>Phone</th>
             <th>Skills</th>
             <th><a href="?perPage=<?= $perPage ?>&sort=status&direction=<?= $statusDir ?><?= $skillQuery ?>">Status</a></th>
+            <th>Info</th>
           </tr>
         </thead>
         <tbody>
@@ -126,6 +129,16 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
             <td><?= (int)$r['employee_id'] ?></td>
             <td><?= s($r['first_name'] . ' ' . $r['last_name']) ?></td>
             <td>
+              <?php if (!empty($r['email'])): ?>
+                <a href="mailto:<?= s($r['email']) ?>"><?= s($r['email']) ?></a>
+              <?php endif; ?>
+            </td>
+            <td>
+              <?php if (!empty($r['phone'])): ?>
+                <a href="tel:<?= s($r['phone']) ?>"><?= s($r['phone']) ?></a>
+              <?php endif; ?>
+            </td>
+            <td>
               <?php foreach (parseSkillProficiencies($r['skills']) as $sk):
                   $cls = skillClass($sk['name'], $skillClasses);
                   $prof = $sk['proficiency'] !== '' ? ' (' . formatProficiency($sk['proficiency']) . ')' : '';
@@ -134,6 +147,23 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
               <?php endforeach; ?>
             </td>
             <td><?= statusBadge((string)($r['status'] ?? '')) ?></td>
+            <td>
+              <?php
+                $info = '';
+                if (!empty($r['email'])) {
+                    $e = s($r['email']);
+                    $info .= "Email: <a href='mailto:$e'>$e</a>";
+                }
+                if (!empty($r['phone'])) {
+                    $p = s($r['phone']);
+                    if ($info !== '') { $info .= '<br>'; }
+                    $info .= "Phone: <a href='tel:$p'>$p</a>";
+                }
+              ?>
+              <?php if ($info !== ''): ?>
+                <i class="bi bi-info-circle" data-bs-toggle="tooltip" data-bs-html="true" title="<?= $info ?>"></i>
+              <?php endif; ?>
+            </td>
           </tr>
         <?php endforeach; ?>
         </tbody>
@@ -195,6 +225,9 @@ $(function(){
       if(res.ok){location.reload();}else{alert(res.error||'Error');}
     },'json');
   });
+
+  const tooltipTriggerList=[].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.map(el=>new bootstrap.Tooltip(el));
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- include people.email and people.phone in employee data provider
- show Email and Phone columns in employees list with mailto/tel links and tooltip info

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689f7d1538c0832f9f03686ca8ababb2