### PR TITLE
feat: toast on employee save

### DIFF
--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -33,6 +33,7 @@ $roles = Role::all($pdo);
   <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 </head>
 <body>
+  <div class="toast-container position-fixed top-0 end-0 p-3" id="toastContainer"></div>
 <?php
 /** HTML escape */
 function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }

--- a/public/js/assignments.js
+++ b/public/js/assignments.js
@@ -460,6 +460,17 @@
     submit(true);
   });
 
+  function handleEmployeesUpdated(){
+    const modal=document.getElementById('assignmentsModal');
+    if(modal && modal.classList.contains('show')){
+      fetchEligible();
+    }
+  }
+  window.addEventListener('employees:updated', handleEmployeesUpdated);
+  window.addEventListener('storage', function(e){
+    if(e.key==='employeesUpdated') handleEmployeesUpdated();
+  });
+
   function debounce(fn, ms) {
     let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
   }

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -33,6 +33,20 @@
       var html = '<ul>' + list.map(function(e){return '<li>'+e+'</li>';}).join('') + '</ul>';
       errBox.innerHTML = html;
     }
+    function showToast(msg){
+      var container=document.getElementById('toastContainer');
+      if(!container||typeof bootstrap==='undefined') return;
+      var el=document.createElement('div');
+      el.className='toast align-items-center text-bg-success border-0';
+      el.setAttribute('role','alert');
+      el.setAttribute('aria-live','assertive');
+      el.setAttribute('aria-atomic','true');
+      el.innerHTML='<div class="d-flex"><div class="toast-body"></div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>';
+      el.querySelector('.toast-body').textContent=msg;
+      container.appendChild(el);
+      var toast=new bootstrap.Toast(el,{delay:2000});
+      toast.show();
+    }
     form.addEventListener('submit', function(e){
       e.preventDefault();
       showErrors([]);
@@ -58,8 +72,10 @@
         return resp.json();
       }).then(function(data){
         if(data && data.ok){
-          alert('Employee saved');
-          window.location.href = 'employees.php';
+          try{localStorage.setItem('employeesUpdated',Date.now().toString());}catch(_){ }
+          try{window.dispatchEvent(new Event('employees:updated'));}catch(_){ }
+          showToast('Employee saved');
+          setTimeout(function(){window.location.href='employees.php';},800);
           return;
         }
         var errs = [];


### PR DESCRIPTION
## Summary
- replace alert with Bootstrap toast when saving employee
- refresh assignments when employees are added so jobs can search/edit new staff

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a05c1dc284832f9feadd1f67b66743