### PR TITLE
Refactor employee form into reusable template

### DIFF
--- a/public/add_employee.php
+++ b/public/add_employee.php
@@ -1,2 +1,10 @@
 <?php
+declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
+
+$mode     = 'add';
+$employee = [];
+$skillIds = [];
+
 require __DIR__ . '/employee_form.php';
+

--- a/public/edit_employee.php
+++ b/public/edit_employee.php
@@ -3,17 +3,13 @@ declare(strict_types=1);
 require __DIR__ . '/_cli_guard.php';
 
 require_once __DIR__ . '/../config/database.php';
-require_once __DIR__ . '/../models/JobType.php';
-require_once __DIR__ . '/../models/Role.php';
-require_once __DIR__ . '/_csrf.php';
-require_once __DIR__ . '/../config/api_keys.php';
 
-$pdo   = getPDO();
-$__csrf = csrf_token();
+$pdo = getPDO();
 
-$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$employee = null;
-$skillIds = [];
+$id        = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$employee  = null;
+$skillIds  = [];
+
 if ($id > 0) {
     $st = $pdo->prepare(
         'SELECT e.id, e.person_id, e.employment_type, e.hire_date, e.status, e.role_id,
@@ -28,7 +24,6 @@ if ($id > 0) {
         $st->execute([':id' => $id]);
         $employee = $st->fetch(PDO::FETCH_ASSOC) ?: null;
         if ($employee) {
-            // employee_skills stores job_type_id; fetch those ids for the form
             $st2 = $pdo->prepare('SELECT job_type_id FROM employee_skills WHERE employee_id = :id');
             if ($st2) {
                 $st2->execute([':id' => $id]);
@@ -42,136 +37,7 @@ if ($id > 0) {
     }
 }
 
-/** @var list<array{id:int|string,name:string}> $skills */
-$skills = JobType::all($pdo);
-/** @var list<array{id:int|string,name:string}> $roles */
-$roles = Role::all($pdo);
-?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Edit Employee</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-<body>
-<?php
-/** HTML escape */
-function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
-/** Sticky helper */
-function sticky(string $name, ?string $default = null): string {
-    $v = $_POST[$name] ?? $_GET[$name] ?? $default ?? '';
-    return is_string($v) ? $v : (string)$v;
-}
-function stickyArr(string $name, array $default = []): array {
-    $v = $_POST[$name] ?? $default;
-    return is_array($v) ? $v : [];
-}
-?>
-  <h1>Edit Employee</h1>
-  <?php if (!$employee): ?>
-    <p>Employee not found.</p>
-  <?php else: ?>
-    <form method="post" action="employee_save.php" autocomplete="off">
-      <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
-      <input type="hidden" name="id" value="<?= (int)$id ?>">
+$mode = 'edit';
 
-      <fieldset>
-        <legend>Personal Information</legend>
-        <label>First Name
-          <input type="text" name="first_name" maxlength="50" value="<?= s(sticky('first_name', $employee['first_name'] ?? '')) ?>" required>
-        </label>
-        <label>Last Name
-          <input type="text" name="last_name" maxlength="50" value="<?= s(sticky('last_name', $employee['last_name'] ?? '')) ?>" required>
-        </label>
-        <label>Email
-          <input type="email" name="email" value="<?= s(sticky('email', $employee['email'] ?? '')) ?>" required>
-        </label>
-        <label>Phone
-          <input type="tel" name="phone" value="<?= s(sticky('phone', $employee['phone'] ?? '')) ?>" required>
-        </label>
-      </fieldset>
+require __DIR__ . '/employee_form.php';
 
-      <fieldset>
-        <legend>Contact &amp; Address</legend>
-        <label>Address Line 1
-          <input type="text" id="address_line1" name="address_line1" value="<?= s(sticky('address_line1', $employee['address_line1'] ?? '')) ?>" required>
-        </label>
-        <label>Address Line 2
-          <input type="text" id="address_line2" name="address_line2" value="<?= s(sticky('address_line2', $employee['address_line2'] ?? '')) ?>">
-        </label>
-        <label>City
-          <input type="text" id="city" name="city" value="<?= s(sticky('city', $employee['city'] ?? '')) ?>" required>
-        </label>
-        <label>State
-          <input type="text" id="state" name="state" value="<?= s(sticky('state', $employee['state'] ?? '')) ?>" required>
-        </label>
-        <label>Postal Code
-          <input type="text" id="postal_code" name="postal_code" value="<?= s(sticky('postal_code', $employee['postal_code'] ?? '')) ?>" required>
-        </label>
-        <input type="hidden" id="home_address_lat" name="home_address_lat" value="<?= s(sticky('home_address_lat', isset($employee['latitude']) ? (string)$employee['latitude'] : '')) ?>">
-        <input type="hidden" id="home_address_lon" name="home_address_lon" value="<?= s(sticky('home_address_lon', isset($employee['longitude']) ? (string)$employee['longitude'] : '')) ?>">
-        <input type="hidden" id="google_place_id" name="google_place_id" value="<?= s(sticky('google_place_id', $employee['google_place_id'] ?? '')) ?>">
-      </fieldset>
-
-      <fieldset>
-        <legend>Employment Details</legend>
-        <label>Employment Type
-          <?php $et = sticky('employment_type', $employee['employment_type'] ?? ''); ?>
-          <select name="employment_type" required>
-            <option value="">-- Select --</option>
-            <option value="Full-Time" <?= $et==='Full-Time'? 'selected':''; ?>>Full-Time</option>
-            <option value="Part-Time" <?= $et==='Part-Time'? 'selected':''; ?>>Part-Time</option>
-            <option value="Contractor" <?= $et==='Contractor'? 'selected':''; ?>>Contractor</option>
-          </select>
-        </label>
-        <label>Hire Date
-          <input type="date" name="hire_date" value="<?= s(sticky('hire_date', $employee['hire_date'] ?? '')) ?>" required>
-        </label>
-        <label>Status
-          <?php $st = sticky('status', $employee['status'] ?? 'Active'); ?>
-          <select name="status" required>
-            <option value="Active" <?= $st==='Active'? 'selected':''; ?>>Active</option>
-            <option value="Inactive" <?= $st==='Inactive'? 'selected':''; ?>>Inactive</option>
-          </select>
-        </label>
-        <label>Role
-          <select name="role_id">
-            <?php $selRole = sticky('role_id', isset($employee['role_id']) ? (string)$employee['role_id'] : ''); ?>
-            <option value="">-- Select --</option>
-            <?php foreach ($roles as $role): ?>
-              <?php $rid = (string)$role['id']; $rname = (string)$role['name']; ?>
-              <option value="<?= s($rid) ?>" <?= $selRole===$rid ? 'selected' : '' ?>><?= s($rname) ?></option>
-            <?php endforeach; ?>
-          </select>
-        </label>
-      </fieldset>
-
-      <fieldset>
-        <legend>Skills</legend>
-        <?php $selSkills = stickyArr('skills', $skillIds); ?>
-        <?php foreach ($skills as $sk): ?>
-          <?php $sid = (string)$sk['id']; $sname = (string)$sk['name']; ?>
-          <label>
-            <input type="checkbox" name="skills[]" value="<?= $sid ?>" <?= in_array($sid, $selSkills, true) ? 'checked' : '' ?>>
-            <?= s($sname) ?>
-          </label>
-        <?php endforeach; ?>
-      </fieldset>
-
-      <button type="submit">Save Changes</button>
-      <button type="button" onclick="window.location.href='employees.php'">Cancel</button>
-    </form>
-  <?php endif; ?>
-  <script src="https://maps.googleapis.com/maps/api/js?key=<?= htmlspecialchars(MAPS_API_KEY, ENT_QUOTES, 'UTF-8') ?>&libraries=places"></script>
-  <script src="js/google_address_autocomplete.js"></script>
-  <script>
-  document.addEventListener('DOMContentLoaded', function () {
-      initializeAddressAutocomplete('address_line1', {
-          latitude: 'home_address_lat',
-          longitude: 'home_address_lon'
-      });
-  });
-  </script>
-</body>
-</html>

--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -1,6 +1,5 @@
 <?php
 declare(strict_types=1);
-require __DIR__ . '/_cli_guard.php';
 
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/../models/JobType.php';
@@ -8,22 +7,40 @@ require_once __DIR__ . '/../models/Role.php';
 require_once __DIR__ . '/_csrf.php';
 require_once __DIR__ . '/../config/api_keys.php';
 
-$pdo   = getPDO();
+$pdo    = getPDO();
 $__csrf = csrf_token();
 
-// Fetch job types to use as skills (id,name)
+$mode     = $mode ?? 'add';
+$employee = $employee ?? [];
+$skillIds = $skillIds ?? [];
+$isEdit   = $mode === 'edit';
+
 /** @var list<array{id:int|string,name:string}> $skills */
 $skills = JobType::all($pdo);
-
-// Fetch available roles
 /** @var list<array{id:int|string,name:string}> $roles */
 $roles = Role::all($pdo);
+
+/** HTML escape */
+function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
+
+/** Sticky helper */
+function sticky(string $name, ?string $default = null): string {
+    global $employee;
+    $v = $_POST[$name] ?? $_GET[$name] ?? $employee[$name] ?? $default ?? '';
+    return is_string($v) ? $v : (string)$v;
+}
+
+/** Sticky helper for arrays */
+function stickyArr(string $name, array $default = []): array {
+    $v = $_POST[$name] ?? $default;
+    return is_array($v) ? $v : [];
+}
 ?>
 <!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Add Employee</title>
+  <title><?= $isEdit ? 'Edit Employee' : 'Add Employee' ?></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="css/employee_form.css">
@@ -34,87 +51,79 @@ $roles = Role::all($pdo);
 </head>
 <body>
   <div class="toast-container position-fixed top-0 end-0 p-3" id="toastContainer"></div>
-<?php
-/** HTML escape */
-function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
-/** Sticky helper */
-function sticky(string $name, ?string $default = null): string {
-    $v = $_POST[$name] ?? $_GET[$name] ?? $default ?? '';
-    return is_string($v) ? $v : (string)$v;
-}
-function stickyArr(string $name): array {
-    $v = $_POST[$name] ?? [];
-    return is_array($v) ? $v : [];
-}
-?>
   <div class="container mt-4">
-    <h1 class="mb-4">Add Employee</h1>
+    <h1 class="mb-4"><?= $isEdit ? 'Edit Employee' : 'Add Employee' ?></h1>
+    <?php if ($isEdit && !$employee): ?>
+      <p>Employee not found.</p>
+    <?php else: ?>
     <div id="form-errors" class="text-danger mb-3"></div>
-    <form id="employeeForm" method="post" action="employee_save.php" autocomplete="off" class="needs-validation" novalidate>
+    <form id="employeeForm" method="post" action="employee_save.php" autocomplete="off" class="needs-validation" novalidate data-mode="<?= $isEdit ? 'edit' : 'add' ?>">
       <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
+      <?php if ($isEdit): ?>
+        <input type="hidden" name="id" value="<?= s((string)($employee['id'] ?? '')) ?>">
+      <?php endif; ?>
 
       <fieldset class="row g-3">
         <legend class="col-12">Personal Information</legend>
         <div class="col-md-6">
           <label class="form-label" for="first_name">First Name <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="text" class="form-control" id="first_name" name="first_name" maxlength="50" value="<?= s(sticky('first_name')) ?>" required aria-required="true">
+          <input type="text" class="form-control" id="first_name" name="first_name" maxlength="50" value="<?= s(sticky('first_name', $employee['first_name'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">First name is required.</div>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="last_name">Last Name <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="text" class="form-control" id="last_name" name="last_name" maxlength="50" value="<?= s(sticky('last_name')) ?>" required aria-required="true">
+          <input type="text" class="form-control" id="last_name" name="last_name" maxlength="50" value="<?= s(sticky('last_name', $employee['last_name'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">Last name is required.</div>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="email">Email <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="email" class="form-control" id="email" name="email" value="<?= s(sticky('email')) ?>" required aria-required="true">
+          <input type="email" class="form-control" id="email" name="email" value="<?= s(sticky('email', $employee['email'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">Valid email is required.</div>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="phone">Phone <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-
-          <input type="tel" class="form-control" id="phone" name="phone" value="<?= s(sticky('phone')) ?>" required aria-required="true" placeholder="(xxx) xxx-xxxx" maxlength="14">
+          <input type="tel" class="form-control" id="phone" name="phone" value="<?= s(sticky('phone', $employee['phone'] ?? '')) ?>" required aria-required="true" placeholder="(xxx) xxx-xxxx" maxlength="14">
           <div class="invalid-feedback">Valid phone is required.</div>
         </div>
-        </fieldset>
+      </fieldset>
 
       <fieldset class="row g-3">
         <legend class="col-12">Contact &amp; Address</legend>
         <div class="col-md-6">
           <label class="form-label" for="address_line1">Address Line 1 <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="text" class="form-control" id="address_line1" name="address_line1" value="<?= s(sticky('address_line1')) ?>" required aria-required="true">
+          <input type="text" class="form-control" id="address_line1" name="address_line1" value="<?= s(sticky('address_line1', $employee['address_line1'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">Address line 1 is required.</div>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="address_line2">Address Line 2</label>
-          <input type="text" class="form-control" id="address_line2" name="address_line2" value="<?= s(sticky('address_line2')) ?>">
+          <input type="text" class="form-control" id="address_line2" name="address_line2" value="<?= s(sticky('address_line2', $employee['address_line2'] ?? '')) ?>">
         </div>
         <div class="col-md-4">
           <label class="form-label" for="city">City <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="text" class="form-control" id="city" name="city" value="<?= s(sticky('city')) ?>" required aria-required="true">
+          <input type="text" class="form-control" id="city" name="city" value="<?= s(sticky('city', $employee['city'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">City is required.</div>
         </div>
         <div class="col-md-4">
           <label class="form-label" for="state">State <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="text" class="form-control" id="state" name="state" value="<?= s(sticky('state')) ?>" required aria-required="true">
+          <input type="text" class="form-control" id="state" name="state" value="<?= s(sticky('state', $employee['state'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">State is required.</div>
         </div>
         <div class="col-md-4">
           <label class="form-label" for="postal_code">Postal Code <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="text" class="form-control" id="postal_code" name="postal_code" value="<?= s(sticky('postal_code')) ?>" required aria-required="true">
+          <input type="text" class="form-control" id="postal_code" name="postal_code" value="<?= s(sticky('postal_code', $employee['postal_code'] ?? '')) ?>" required aria-required="true">
           <div class="invalid-feedback">Postal code is required.</div>
         </div>
-        <input type="hidden" id="home_address_lat" name="home_address_lat" value="<?= s(sticky('home_address_lat')) ?>">
-        <input type="hidden" id="home_address_lon" name="home_address_lon" value="<?= s(sticky('home_address_lon')) ?>">
-        <input type="hidden" id="google_place_id" name="google_place_id" value="<?= s(sticky('google_place_id')) ?>">
+        <input type="hidden" id="home_address_lat" name="home_address_lat" value="<?= s(sticky('home_address_lat', isset($employee['latitude']) ? (string)$employee['latitude'] : '')) ?>">
+        <input type="hidden" id="home_address_lon" name="home_address_lon" value="<?= s(sticky('home_address_lon', isset($employee['longitude']) ? (string)$employee['longitude'] : '')) ?>">
+        <input type="hidden" id="google_place_id" name="google_place_id" value="<?= s(sticky('google_place_id', $employee['google_place_id'] ?? '')) ?>">
       </fieldset>
 
       <fieldset class="row g-3">
         <legend class="col-12">Employment Details</legend>
         <div class="col-md-6">
           <label class="form-label" for="employment_type">Employment Type <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
+          <?php $et = sticky('employment_type', $employee['employment_type'] ?? ''); ?>
           <select class="form-select" id="employment_type" name="employment_type" required aria-required="true">
-            <?php $et = sticky('employment_type'); ?>
             <option value="">-- Select --</option>
             <option value="Full-Time" <?= $et==='Full-Time'? 'selected':''; ?>>Full-Time</option>
             <option value="Part-Time" <?= $et==='Part-Time'? 'selected':''; ?>>Part-Time</option>
@@ -124,12 +133,12 @@ function stickyArr(string $name): array {
         </div>
         <div class="col-md-6">
           <label class="form-label" for="hire_date">Hire Date <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <input type="date" class="form-control" id="hire_date" name="hire_date" value="<?= s(sticky('hire_date', date('Y-m-d'))) ?>" required aria-required="true">
+          <input type="date" class="form-control" id="hire_date" name="hire_date" value="<?= s(sticky('hire_date', $employee['hire_date'] ?? date('Y-m-d'))) ?>" required aria-required="true">
           <div class="invalid-feedback">Hire date is required.</div>
         </div>
         <div class="col-md-6">
           <label class="form-label" for="status">Status <span class="text-danger">*</span><span class="visually-hidden"> required</span></label>
-          <?php $st = sticky('status', 'Active'); ?>
+          <?php $st = sticky('status', $employee['status'] ?? 'Active'); ?>
           <select class="form-select" id="status" name="status" required aria-required="true">
             <option value="Active" <?= $st==='Active'? 'selected':''; ?>>Active</option>
             <option value="Inactive" <?= $st==='Inactive'? 'selected':''; ?>>Inactive</option>
@@ -139,7 +148,7 @@ function stickyArr(string $name): array {
         <div class="col-md-6">
           <label class="form-label">Role
             <select class="form-select" name="role_id">
-              <?php $selRole = sticky('role_id'); ?>
+              <?php $selRole = sticky('role_id', isset($employee['role_id']) ? (string)$employee['role_id'] : ''); ?>
               <option value="">-- Select --</option>
               <?php foreach ($roles as $role): ?>
                 <?php $rid = (string)$role['id']; $rname = (string)$role['name']; ?>
@@ -152,7 +161,7 @@ function stickyArr(string $name): array {
 
       <fieldset class="row g-3">
         <legend class="col-12">Skills</legend>
-        <?php $selSkills = stickyArr('skills'); ?>
+        <?php $selSkills = stickyArr('skills', $skillIds); ?>
         <div class="col-12">
           <label class="form-label">Select Skills
             <select class="form-select" id="skills" name="skills[]" multiple>
@@ -166,10 +175,11 @@ function stickyArr(string $name): array {
       </fieldset>
 
       <div class="mt-3">
-        <button type="submit" class="btn btn-primary">Save Employee</button>
+        <button type="submit" class="btn btn-primary"><?= $isEdit ? 'Save Changes' : 'Save Employee' ?></button>
         <button type="button" class="btn btn-secondary" onclick="window.location.href='employees.php'">Cancel</button>
       </div>
     </form>
+    <?php endif; ?>
   </div>
   <script src="js/employee_form.js"></script>
   <script src="https://maps.googleapis.com/maps/api/js?key=<?= htmlspecialchars(MAPS_API_KEY, ENT_QUOTES, 'UTF-8') ?>&libraries=places"></script>
@@ -184,3 +194,4 @@ function stickyArr(string $name): array {
   </script>
 </body>
 </html>
+

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -2,6 +2,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     var form = document.getElementById('employeeForm');
     if (!form) return;
+    var mode = form.getAttribute('data-mode') || 'add';
     var phoneEl = form.querySelector('#phone');
     if (phoneEl) {
       phoneEl.addEventListener('input', function (e) {
@@ -74,7 +75,7 @@
         if(data && data.ok){
           try{localStorage.setItem('employeesUpdated',Date.now().toString());}catch(_){ }
           try{window.dispatchEvent(new Event('employees:updated'));}catch(_){ }
-          showToast('Employee saved');
+          showToast(mode === 'edit' ? 'Employee updated' : 'Employee saved');
           setTimeout(function(){window.location.href='employees.php';},800);
           return;
         }


### PR DESCRIPTION
## Summary
- Refactor `employee_form.php` into template driven by `$mode`, `$employee`, and `$skillIds`
- Adjust add and edit entry points to use the shared form template
- Update form JavaScript to respect form mode and show appropriate status messaging

## Testing
- `php -l public/employee_form.php`
- `php -l public/add_employee.php`
- `php -l public/edit_employee.php`
- `vendor/bin/phpunit` *(fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0619480c8832f8aa47792d2d7e1d2