### PR TITLE
Add skills schema and references

### DIFF
--- a/bin/cleanup_orphans.php
+++ b/bin/cleanup_orphans.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 /**
  * bin/cleanup_orphans.php
  * Dev-only utility to remove rows that would block FK creation.
- * - Deletes employee_skills rows whose employee/job_type no longer exist
+ * - Deletes employee_skills rows whose employee/skill no longer exist
+ * - Deletes jobtype_skills rows whose skill no longer exist
  * - Deletes job_employee_assignment rows whose job/employee no longer exist
  *
  * Idempotent. Prints counts removed.
@@ -30,32 +31,41 @@ try {
     ");
     out("[OK] employee_skills deleted (no employee): " . (int)$n1);
 
-    // 2) employee_skills → job_types
+    // 2) employee_skills → skills
     $n2 = $pdo->exec("
         DELETE s
         FROM employee_skills s
-        LEFT JOIN job_types t ON t.id = s.job_type_id
-        WHERE t.id IS NULL
+        LEFT JOIN skills sk ON sk.id = s.skill_id
+        WHERE sk.id IS NULL
     ");
-    out("[OK] employee_skills deleted (no job_type): " . (int)$n2);
+    out("[OK] employee_skills deleted (no skill): " . (int)$n2);
 
     // 3) job_employee_assignment → jobs
-    $n5 = $pdo->exec("
+    $n3 = $pdo->exec("
         DELETE a
         FROM job_employee_assignment a
         LEFT JOIN jobs j ON j.id = a.job_id
         WHERE j.id IS NULL
     ");
-    out("[OK] job_employee_assignment deleted (no job): " . (int)$n5);
+    out("[OK] job_employee_assignment deleted (no job): " . (int)$n3);
 
     // 4) job_employee_assignment → employees
-    $n6 = $pdo->exec("
+    $n4 = $pdo->exec("
         DELETE a
         FROM job_employee_assignment a
         LEFT JOIN employees e ON e.id = a.employee_id
         WHERE e.id IS NULL
     ");
-    out("[OK] job_employee_assignment deleted (no employee): " . (int)$n6);
+    out("[OK] job_employee_assignment deleted (no employee): " . (int)$n4);
+
+    // 5) jobtype_skills → skills
+    $n5 = $pdo->exec("
+        DELETE js
+        FROM jobtype_skills js
+        LEFT JOIN skills s ON s.id = js.skill_id
+        WHERE s.id IS NULL
+    ");
+    out("[OK] jobtype_skills deleted (no skill): " . (int)$n5);
 
     $pdo->commit();
     out("Done.");

--- a/bin/schema_check.php
+++ b/bin/schema_check.php
@@ -120,7 +120,9 @@ $required = [
   'customers' => ['id','first_name','last_name'],
   'jobs' => ['id','customer_id','description','status','scheduled_date','scheduled_time','duration_minutes'],
   'job_types' => ['id','name'],
-  'employee_skills' => ['employee_id','job_type_id','proficiency'],
+  'skills' => ['id','name','description'],
+  'employee_skills' => ['employee_id','skill_id','proficiency'],
+  'jobtype_skills' => ['job_type_id','skill_id'],
   'employee_availability' => ['id','employee_id','day_of_week','start_time','end_time'],
   'job_employee_assignment' => ['id','job_id','employee_id','assigned_at'],
 ];
@@ -134,7 +136,7 @@ foreach ($required as $t => $colsNeed) {
 }
 
 // AUTO_INCREMENT PKs
-foreach (['people','employees','customers','jobs','job_types','employee_availability','job_employee_assignment'] as $t) {
+foreach (['people','employees','customers','jobs','job_types','skills','employee_availability','job_employee_assignment'] as $t) {
     if (!tableExists($pdo, $t)) continue;
     if (!hasAutoPk(columns($pdo, $t), 'id')) {
         $issues[] = "Primary key AUTO_INCREMENT missing or not primary on $t.id";
@@ -147,7 +149,11 @@ $fkExpect = [
   'jobs'      => [['cols'=>['customer_id'], 'ref'=>'customers', 'refcols'=>['id']]],
   'employee_skills' => [
       ['cols'=>['employee_id'],'ref'=>'employees','refcols'=>['id']],
-      ['cols'=>['job_type_id'], 'ref'=>'job_types','refcols'=>['id']],
+      ['cols'=>['skill_id'], 'ref'=>'skills','refcols'=>['id']],
+  ],
+  'jobtype_skills' => [
+      ['cols'=>['job_type_id'],'ref'=>'job_types','refcols'=>['id']],
+      ['cols'=>['skill_id'],'ref'=>'skills','refcols'=>['id']],
   ],
   'job_employee_assignment' => [
       ['cols'=>['job_id'],'ref'=>'jobs','refcols'=>['id']],
@@ -177,6 +183,14 @@ if (tableExists($pdo,'employee_availability') &&
 if (tableExists($pdo,'job_employee_assignment') &&
     !hasUniqueIndex($pdo,'job_employee_assignment',['job_id','employee_id'],'uniq_assignment_job_emp')) {
     $issues[] = "Missing UNIQUE index on job_employee_assignment(job_id, employee_id)";
+}
+if (tableExists($pdo,'employee_skills') &&
+    !hasUniqueIndex($pdo,'employee_skills',['employee_id','skill_id'],'uq_employee_skill')) {
+    $issues[] = "Missing UNIQUE index on employee_skills(employee_id, skill_id)";
+}
+if (tableExists($pdo,'jobtype_skills') &&
+    !hasUniqueIndex($pdo,'jobtype_skills',['job_type_id','skill_id'],'uq_jobtype_skill')) {
+    $issues[] = "Missing UNIQUE index on jobtype_skills(job_type_id, skill_id)";
 }
 
 // Data health


### PR DESCRIPTION
## Summary
- create `skills` and `jobtype_skills` tables with necessary foreign keys
- refactor `employee_skills` to reference `skills` and ensure unique indexes
- update schema checks and orphan cleanup for new skill relations

## Testing
- `php -l bin/ensure_core_schema.php`
- `php -l bin/schema_check.php`
- `php -l bin/cleanup_orphans.php`
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a07c97ac50832f9099b2027cdcad9c