### PR TITLE
Add Skill model and update employee skill lookups

### DIFF
--- a/models/EmployeeDataProvider.php
+++ b/models/EmployeeDataProvider.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 final class EmployeeDataProvider
 {
     /**
+     * @param ?list<string> $skills
      * @return array{rows:array<int, array{
      *   employee_id:int,
      *   first_name:string,
@@ -42,10 +43,10 @@ final class EmployeeDataProvider
                 $where .= " AND e.id IN (
                     SELECT es.employee_id
                     FROM employee_skills es
-                    JOIN job_types jt ON jt.id = es.job_type_id
-                    WHERE jt.name IN (" . implode(',', $placeholders) . ")
+                    JOIN skills s ON s.id = es.skill_id
+                    WHERE s.name IN (" . implode(',', $placeholders) . ")
                     GROUP BY es.employee_id
-                    HAVING COUNT(DISTINCT jt.name) = $count
+                    HAVING COUNT(DISTINCT s.name) = $count
                 )";
             }
         }
@@ -80,8 +81,8 @@ final class EmployeeDataProvider
                    p.phone,
                    COALESCE(
                        GROUP_CONCAT(
-                           DISTINCT CONCAT(jt.name, '|', COALESCE(es.proficiency, ''))
-                           ORDER BY jt.name SEPARATOR ','
+                           DISTINCT CONCAT(s.name, '|', COALESCE(es.proficiency, ''))
+                           ORDER BY s.name SEPARATOR ','
                        ),
                        ''
                    ) AS skills,
@@ -90,7 +91,7 @@ final class EmployeeDataProvider
             FROM employees e
             JOIN people p ON p.id = e.person_id
             LEFT JOIN employee_skills es ON es.employee_id = e.id
-            LEFT JOIN job_types jt ON jt.id = es.job_type_id
+            LEFT JOIN skills s ON s.id = es.skill_id
             $where
             GROUP BY e.id, p.first_name, p.last_name, p.email, p.phone, e.is_active, e.status
             ORDER BY $orderBy

--- a/models/Skill.php
+++ b/models/Skill.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+final class Skill
+{
+    /**
+     * Return all skills.
+     *
+     * @return list<array{id:int|string,name:string}>
+     */
+    public static function all(PDO $pdo): array
+    {
+        $st = $pdo->prepare('SELECT id, name FROM skills ORDER BY name, id');
+        if ($st === false) {
+            return [];
+        }
+        $st->execute();
+        /** @var list<array{id:int|string,name:string}> $rows */
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+        return $rows;
+    }
+
+    /**
+     * Fetch skills for a given employee.
+     *
+     * @return list<array{id:int|string,name:string}>
+     */
+    public static function forEmployee(PDO $pdo, int $employeeId): array
+    {
+        try {
+            $st = $pdo->prepare(
+                'SELECT s.id, s.name
+                 FROM employee_skills es
+                 JOIN skills s ON s.id = es.skill_id
+                 WHERE es.employee_id = :eid
+                 ORDER BY s.name, s.id'
+            );
+            if ($st === false) {
+                return [];
+            }
+            $st->execute([':eid' => $employeeId]);
+            /** @var list<array{id:int|string,name:string}> $rows */
+            $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+            return $rows;
+        } catch (Throwable $e) {
+            return [];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Skill model with helpers for listing skills and fetching an employee's skills
- switch employee filtering and skill aggregation to reference `skills` table

## Testing
- `make lint` *(fails: Found 97 errors)*
- `./vendor/bin/phpstan analyse models/Skill.php models/EmployeeDataProvider.php`
- `make unit`


------
https://chatgpt.com/codex/tasks/task_e_68a07ca7a68c832f90eb974ebd309963