### PR TITLE
Use Skill model for employee form

### DIFF
--- a/public/add_employee.php
+++ b/public/add_employee.php
@@ -4,7 +4,7 @@ require __DIR__ . '/_cli_guard.php';
 
 $mode     = 'add';
 $employee = [];
-$skillIds = [];
+$skillIds = []; // no preselected skills on add
 
 require __DIR__ . '/employee_form.php';
 

--- a/public/edit_employee.php
+++ b/public/edit_employee.php
@@ -24,7 +24,7 @@ if ($id > 0) {
         $st->execute([':id' => $id]);
         $employee = $st->fetch(PDO::FETCH_ASSOC) ?: null;
         if ($employee) {
-            $st2 = $pdo->prepare('SELECT job_type_id FROM employee_skills WHERE employee_id = :id');
+            $st2 = $pdo->prepare('SELECT skill_id FROM employee_skills WHERE employee_id = :id');
             if ($st2) {
                 $st2->execute([':id' => $id]);
                 $skillIds = array_map('strval', $st2->fetchAll(PDO::FETCH_COLUMN));

--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/../config/database.php';
-require_once __DIR__ . '/../models/JobType.php';
+require_once __DIR__ . '/../models/Skill.php';
 require_once __DIR__ . '/../models/Role.php';
 require_once __DIR__ . '/_csrf.php';
 require_once __DIR__ . '/../config/api_keys.php';
@@ -16,7 +16,7 @@ $skillIds = $skillIds ?? [];
 $isEdit   = $mode === 'edit';
 
 /** @var list<array{id:int|string,name:string}> $skills */
-$skills = JobType::all($pdo);
+$skills = Skill::all($pdo);
 /** @var list<array{id:int|string,name:string}> $roles */
 $roles = Role::all($pdo);
 

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -21,10 +21,11 @@
         e.target.setCustomValidity(valid ? '' : 'Invalid phone number');
       });
     }
+    // Enhance the skills multi-select with Select2 for better UX
     if (typeof $ !== 'undefined' && $.fn.select2) {
-      var skillsEl = $('#skills');
-      if (skillsEl.length) {
-        skillsEl.select2({ width: '100%' });
+      var skillsSelect = $('#skills');
+      if (skillsSelect.length) {
+        skillsSelect.select2({ width: '100%' });
       }
     }
     var errBox = document.getElementById('form-errors');


### PR DESCRIPTION
## Summary
- load skills from Skill model instead of JobType
- select employee skill IDs from employee_skills.skill_id
- ensure Select2 enhances skills multi-select

## Testing
- `make lint` *(fails: Found 97 errors)*
- `make test` *(fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0857896c4832fa833cd8704101050