### PR TITLE
Use new skills fields in job list and assignments

### DIFF
--- a/public/assign.php
+++ b/public/assign.php
@@ -48,7 +48,7 @@ function e(string $v): string { return htmlspecialchars($v, ENT_QUOTES, 'UTF-8')
         <div class="col-md-6"><strong>Customer:</strong> <span id="jobCustomer">—</span></div>
         <div class="col-md-6"><strong>Description:</strong> <span id="jobDesc">—</span></div>
         <div class="col-md-6"><strong>Scheduled:</strong> <span id="jobSched">—</span></div>
-        <div class="col-md-6"><strong>Job Types:</strong> <span id="jobTypes">—</span></div>
+        <div class="col-md-6"><strong>Required Skills:</strong> <span id="jobSkills">—</span></div>
       </div>
 
       <!-- Filters -->
@@ -159,8 +159,8 @@ function loadCandidates() {
     document.getElementById('jobCustomer').textContent = (job.customer && job.customer.name) ? job.customer.name : '—';
     document.getElementById('jobDesc').textContent     = job.description || '—';
     document.getElementById('jobSched').textContent    = (job.scheduledDate ? fmtHuman(job.scheduledDate, job.scheduledTime) : '—');
-    document.getElementById('jobTypes').textContent    = Array.isArray(job.requiredJobTypes) && job.requiredJobTypes.length
-      ? job.requiredJobTypes.map(t=>t.name).join(', ')
+    document.getElementById('jobSkills').textContent   = Array.isArray(job.requiredSkills) && job.requiredSkills.length
+      ? job.requiredSkills.map(s=>s.name).join(', ')
       : '—';
 
     const assignedSet = new Set((curr && curr.employees ? curr.employees : []).map(Number));

--- a/public/js/assignments.js
+++ b/public/js/assignments.js
@@ -160,8 +160,8 @@
 
   function buildSkillFilter(data) {
     const skillNames = new Map(); // id -> name
-    (data.job?.requiredJobTypeIds || []).forEach((id, i) => {
-      const name = (data.job?.requiredJobTypeNames || [])[i] || `Skill ${id}`;
+    (data.job?.requiredSkillIds || []).forEach((id, i) => {
+      const name = (data.job?.requiredSkillNames || [])[i] || `Skill ${id}`;
       if (id != null) skillNames.set(id, name);
     });
     (data.employees || []).forEach(emp => {

--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -59,7 +59,7 @@
         tr.appendChild(custCell);
         // Job skills
         const jsCell=document.createElement('td');
-        const skills = job.job_skills?.length ? job.job_skills : job.job_types;
+        const skills = job.skills?.length ? job.skills : job.job_skills;
         if(skills?.length){
           jsCell.innerHTML=skills.map(s=>`<span class="badge bg-secondary-subtle text-secondary border me-1">${h(s.name)}</span>`).join('');
         } else {


### PR DESCRIPTION
## Summary
- Read skill badges from `job.skills` (fallback to `job.job_skills`) when listing jobs
- Use `requiredSkillIds/Names` in assignments script
- Show required skills in assignment page summary

## Testing
- `make lint` *(fails: 88 errors)*
- `make test` *(unit tests pass; integration tests fail: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b632bb0832f99ffe40ce1895c82