### PR TITLE
Refactor job workflow to match employee patterns

### DIFF
--- a/public/add_job.php
+++ b/public/add_job.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
+
+$mode       = 'add';
+$job        = [];
+$jobTypeIds = [];
+
+require __DIR__ . '/job_form.php';

--- a/public/edit_job.php
+++ b/public/edit_job.php
@@ -2,63 +2,15 @@
 declare(strict_types=1);
 require __DIR__ . '/_cli_guard.php';
 
-
-
 require_once __DIR__ . '/../config/database.php';
-require_once __DIR__ . '/_csrf.php';
 require_once __DIR__ . '/../models/Job.php';
-$id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-$job = $id > 0 ? Job::getJobAndCustomerDetails(getPDO(), $id) : null;
-$statuses = Job::allowedStatuses();
-$jobTypes = $id > 0 ? Job::getJobTypesForJob(getPDO(), $id) : [];
-$current  = strtolower((string)($job['status'] ?? 'draft'));
 
 $pdo = getPDO();
-$__csrf = csrf_token();
-?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Edit Job</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
-<body>
+$id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$job = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
+$jobTypes = $id > 0 ? Job::getJobTypesForJob($pdo, $id) : [];
+$jobTypeIds = array_map(static fn(array $r): string => (string)$r['id'], $jobTypes);
 
-<?php
-/** HTML escape */
-function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
-/** Sticky helper */
-function sticky(string $name, ?string $default = null): string {
-    $v = $_POST[$name] ?? $_GET[$name] ?? $default ?? '';
-    return is_string($v) ? $v : (string)$v;
-}
-?>
+$mode = 'edit';
 
-  <h1>Edit Job</h1>
-  <?php if (!$job): ?>
-    <p>Job not found.</p>
-  <?php else: ?>
-    <form method="post" action="job_save.php" autocomplete="off">
-      <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
-      <input type="hidden" name="id" value="<?= (int)$id ?>">
-      <fieldset>
-        <legend>Details</legend>
-        <div><strong>Description:</strong> <?= s((string)($job['description'] ?? '')) ?></div>
-        <label>Status
-          <select name="status" required>
-            <?php foreach ($statuses as $st): ?>
-              <?php $label = ucwords(str_replace('_',' ', $st)); ?>
-              <option value="<?= s($st) ?>" <?= $st === $current ? 'selected' : '' ?>><?= s($label) ?></option>
-            <?php endforeach; ?>
-          </select>
-        </label>
-        <div><strong>Scheduled:</strong> <?= s((string)($job['scheduled_date'] ?? '')) ?> <?= s((string)($job['scheduled_time'] ?? '')) ?></div>
-        <div><strong>Job Types:</strong> <?= s(implode(', ', array_column($jobTypes, 'name'))) ?></div>
-      </fieldset>
-      <button type="submit">Save Changes</button>
-    </form>
-  <?php endif; ?>
-
-</body>
-</html>
+require __DIR__ . '/job_form.php';

--- a/public/job_process.php
+++ b/public/job_process.php
@@ -42,7 +42,7 @@ if ($duration_min < 0)      $errors[] = 'Duration must be zero or more.';
 if ($status === '')         $errors[] = 'Status is required.';
 
 if ($errors) {
-    redirectWithFlash(($action === 'create' ? 'job_form.php' : "edit_job.php?id={$id}"), 'danger', implode(' ', $errors));
+    redirectWithFlash(($action === 'create' ? 'add_job.php' : "edit_job.php?id={$id}"), 'danger', implode(' ', $errors));
 }
 
 try {

--- a/public/jobs.php
+++ b/public/jobs.php
@@ -43,7 +43,7 @@ $weekLater = date('Y-m-d', strtotime('+7 days'));
   <div class="d-flex align-items-center mb-3">
     <h1 class="h4 m-0 me-2">Jobs</h1>
     <div class="ms-auto">
-      <a href="job_form.php" class="btn btn-primary btn-sm">+ Add Job</a>
+      <a href="add_job.php" class="btn btn-primary btn-sm">+ Add Job</a>
     </div>
   </div>
   <div class="jobs-toolbar d-flex mb-3">

--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -1,0 +1,66 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    var form = document.getElementById('jobForm');
+    if(!form) return;
+    var mode = form.getAttribute('data-mode') || 'add';
+    var errBox = document.getElementById('form-errors');
+    var customerSelect = document.getElementById('customerId');
+    var jtError = document.getElementById('jobTypeError');
+
+    function showErrors(list){
+      if(!errBox) return;
+      if(!list || !list.length){ errBox.textContent=''; return; }
+      var html = '<ul>' + list.map(function(e){return '<li>'+e+'</li>';}).join('') + '</ul>';
+      errBox.innerHTML = html;
+    }
+    function showToast(msg){
+      var container=document.getElementById('toastContainer');
+      if(!container||typeof bootstrap==='undefined') return;
+      var el=document.createElement('div');
+      el.className='toast align-items-center text-bg-success border-0';
+      el.setAttribute('role','alert');
+      el.setAttribute('aria-live','assertive');
+      el.setAttribute('aria-atomic','true');
+      el.innerHTML='<div class="d-flex"><div class="toast-body"></div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div>';
+      el.querySelector('.toast-body').textContent=msg;
+      container.appendChild(el);
+      var toast=new bootstrap.Toast(el,{delay:2000});
+      toast.show();
+    }
+
+    form.addEventListener('submit', function(e){
+      e.preventDefault();
+      showErrors([]);
+      var jtChecks = form.querySelectorAll('input[name="job_types[]"]:checked');
+      var valid = form.checkValidity();
+      if(jtChecks.length===0){ if(jtError){jtError.style.display='block';} valid=false; } else { if(jtError){jtError.style.display='none';} }
+      if(!valid){ form.classList.add('was-validated'); return; }
+      var submitBtn=form.querySelector('button[type="submit"]');
+      var originalHTML = submitBtn ? submitBtn.innerHTML : '';
+      if(submitBtn){ submitBtn.disabled=true; submitBtn.innerHTML='Saving...'; }
+      var fd = new FormData(form);
+      fetch('job_save.php?json=1',{method:'POST', headers:{'Accept':'application/json','X-Requested-With':'XMLHttpRequest'}, body:fd})
+        .then(function(resp){ return resp.json(); })
+        .then(function(data){
+          if(data && data.ok){
+            showToast(mode==='edit'?'Job updated':'Job saved');
+            setTimeout(function(){ window.location.href='jobs.php'; }, 800);
+            return;
+          }
+          var errs=[];
+          if(data && data.errors){ errs=data.errors; }
+          else if(data && data.error){ errs=[data.error]; }
+          else { errs=['Unknown error']; }
+          showErrors(errs);
+          if(errBox) errBox.scrollIntoView({behavior:'smooth'});
+        })
+        .catch(function(){
+          showErrors(['Request failed. Please try again.']);
+          if(errBox) errBox.scrollIntoView({behavior:'smooth'});
+        })
+        .finally(function(){
+          if(submitBtn){ submitBtn.disabled=false; submitBtn.innerHTML=originalHTML; }
+        });
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- Introduce shared job form with add/edit modes and modern Bootstrap layout
- Add dedicated add and edit entry points and client-side JS for async saving
- Update job persistence to handle inserts and updates and wire new pages

## Testing
- `make lint` (fails: Found 89 errors)
- `make test` (fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a0c0759868832fa2ea695129d87624