### PR TITLE
Add 'No Hours' schedule status to employee listings

### DIFF
--- a/models/EmployeeScheduleStatusProvider.php
+++ b/models/EmployeeScheduleStatusProvider.php
@@ -45,7 +45,7 @@ final class EmployeeScheduleStatusProvider
         foreach ($employeeIds as $eid) {
             $intervals = $grouped[$eid] ?? [];
             if ($intervals === []) {
-                $statuses[$eid] = 'Available';
+                $statuses[$eid] = 'No Hours';
                 continue;
             }
             usort($intervals, static fn($a, $b) => $a[0] <=> $b[0]);

--- a/public/employees.php
+++ b/public/employees.php
@@ -62,6 +62,7 @@ function scheduleBadge(string $status): string {
         'available' => '<span class="badge bg-success">Available</span>',
         'booked' => '<span class="badge bg-danger">Booked</span>',
         'partially booked' => '<span class="badge bg-warning text-dark">Partially Booked</span>',
+        'no hours' => '<span class="badge bg-secondary">No Hours</span>',
         default => '<span class="badge bg-secondary">'.s($status).'</span>',
     };
 }
@@ -80,7 +81,7 @@ $scheduleStatuses = EmployeeScheduleStatusProvider::forDate($pdo, $ids, date('Y-
 foreach ($rows as &$r) {
     $eid = (int)$r['employee_id'];
     $r['availability'] = $summaries[$eid] ?? '';
-    $r['schedule_status'] = $scheduleStatuses[$eid] ?? 'Available';
+    $r['schedule_status'] = $scheduleStatuses[$eid] ?? 'No Hours';
 }
 unset($r);
 $total = $data['total'];
@@ -220,6 +221,7 @@ foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
   <div class="mt-3 small">
     <strong>Legend:</strong>
     <span class="badge bg-success me-1">Available</span> Available
+    <span class="badge bg-secondary ms-3 me-1">No Hours</span> No Hours
     <span class="badge bg-danger ms-3 me-1">Booked</span> Booked
     <span class="badge bg-warning text-dark ms-3 me-1">Partially Booked</span> Partially Booked
   </div>


### PR DESCRIPTION
## Summary
- Mark employees with no scheduled jobs as **No Hours**
- Default employee table and badge rendering to the new No Hours status
- Document No Hours in the legend

## Testing
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fee6dfd8832fa43317f0f2973d43