### PR TITLE
Add server-side employee search with URL-based filtering

### DIFF
--- a/models/EmployeeDataProvider.php
+++ b/models/EmployeeDataProvider.php
@@ -7,6 +7,7 @@ final class EmployeeDataProvider
 {
     /**
      * @param ?list<string> $skills
+     * @param ?string $search
      * @return array{rows:array<int, array{
      *   employee_id:int,
      *   first_name:string,
@@ -24,7 +25,8 @@ final class EmployeeDataProvider
         int $page = 1,
         int $perPage = 25,
         ?string $sort = null,
-        ?string $direction = null
+        ?string $direction = null,
+        ?string $search = null
     ): array
     {
         $where = "WHERE 1=1";
@@ -51,7 +53,12 @@ final class EmployeeDataProvider
             }
         }
 
-        $countSql = "SELECT COUNT(*) FROM employees e $where";
+        if ($search !== null && $search !== '') {
+            $where .= " AND (p.first_name LIKE :search OR p.last_name LIKE :search OR p.email LIKE :search OR p.phone LIKE :search)";
+            $params[':search'] = '%' . $search . '%';
+        }
+
+        $countSql = "SELECT COUNT(*) FROM employees e JOIN people p ON p.id = e.person_id $where";
         $countStmt = $pdo->prepare($countSql);
         $countStmt->execute($params);
         $total = (int)$countStmt->fetchColumn();


### PR DESCRIPTION
## Summary
- support optional search term in `EmployeeDataProvider::getFiltered`
- pass `search` query param through employee listing and pagination links
- reload employee list when submitting search instead of filtering rows client-side

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fed0b008832fb59efd74c1da82b2