### PR TITLE
feat: add employee search to availability manager

### DIFF
--- a/public/api/employees/search.php
+++ b/public/api/employees/search.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../../_cli_guard.php';
+require_once __DIR__ . '/../../config/database.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$q  = trim((string)($_GET['q'] ?? ''));
+
+try {
+    $pdo = getPDO();
+    // Optional filter by is_active if column exists
+    $hasIsActive = false;
+    try {
+        $chk = $pdo->query("SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='employees' AND COLUMN_NAME='is_active' LIMIT 1");
+        $hasIsActive = (bool)($chk ? $chk->fetchColumn() : false);
+    } catch (Throwable $e) {
+        $hasIsActive = false;
+    }
+
+    if ($id > 0) {
+        $sql = "SELECT e.id, CONCAT(p.first_name,' ',p.last_name) AS name FROM employees e JOIN people p ON p.id=e.person_id WHERE e.id=:id";
+        if ($hasIsActive) { $sql .= " AND e.is_active=1"; }
+        $st = $pdo->prepare($sql);
+        $st->execute([':id'=>$id]);
+        $row = $st->fetch(PDO::FETCH_ASSOC);
+        echo json_encode($row ? ['id'=>(int)$row['id'], 'name'=>$row['name']] : new stdClass(), JSON_UNESCAPED_SLASHES);
+        exit;
+    }
+
+    if (strlen($q) < 2) {
+        echo json_encode([]);
+        exit;
+    }
+
+    $sql = "SELECT e.id, CONCAT(p.first_name,' ',p.last_name) AS name FROM employees e JOIN people p ON p.id=e.person_id WHERE p.first_name LIKE :q OR p.last_name LIKE :q";
+    if ($hasIsActive) { $sql .= " AND e.is_active=1"; }
+    $sql .= " ORDER BY p.last_name, p.first_name LIMIT 20";
+    $st = $pdo->prepare($sql);
+    $st->execute([':q'=>'%'.$q.'%']);
+    $rows = [];
+    foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
+        $rows[] = ['id'=>(int)$r['id'], 'name'=>$r['name']];
+    }
+    echo json_encode($rows, JSON_UNESCAPED_SLASHES);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode([]);
+}

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -39,47 +39,8 @@ if (($_GET['action'] ?? '') === 'list') {
     json_out(['ok'=>true,'items'=>$rows]);
 }
 
-// Detect if employees.is_active exists; if not, omit the filter
-$hasIsActive = false;
-try {
-    $chk = $pdo->query("
-        SELECT 1
-        FROM information_schema.COLUMNS
-        WHERE TABLE_SCHEMA = DATABASE()
-          AND TABLE_NAME = 'employees'
-          AND COLUMN_NAME = 'is_active'
-        LIMIT 1
-    ");
-    $hasIsActive = (bool)($chk ? $chk->fetchColumn() : false);
-} catch (Throwable $e) {
-    // If information_schema is restricted, just proceed without the filter
-    $hasIsActive = false;
-}
-
-$sql = "
-    SELECT e.id AS employee_id, p.first_name, p.last_name
-    FROM employees e
-    JOIN people p ON p.id = e.person_id
-";
-if ($hasIsActive) {
-    $sql .= " WHERE e.is_active = 1 ";
-}
-$sql .= " ORDER BY p.last_name, p.first_name ";
-
-$employees = [];
-try {
-    $empStmt = $pdo->query($sql);
-    if ($empStmt) { $employees = (array)$empStmt->fetchAll(PDO::FETCH_ASSOC); }
-} catch (Throwable $e) {
-    // If even this fails, keep list empty but render the page
-    error_log('[availability_manager] employees query failed: ' . $e->getMessage());
-}
-
-// Default selected employee (first row if not provided)
+// Selected employee id from query string (if any)
 $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 0;
-if ($selectedEmployeeId <= 0 && isset($employees[0]['employee_id'])) {
-    $selectedEmployeeId = (int)$employees[0]['employee_id'];
-}
 ?>
 <!doctype html>
 <html lang="en">
@@ -109,17 +70,9 @@ if ($selectedEmployeeId <= 0 && isset($employees[0]['employee_id'])) {
         <form id="employeePicker" class="row g-2 align-items-end">
           <div class="col-sm-7 col-md-6 col-lg-5">
             <label class="form-label">Employee</label>
-            <select id="employee_id" name="employee_id" class="form-select" required>
-              <?php foreach ($employees as $e): ?>
-                <?php $eid = (int)$e['employee_id']; ?>
-                <option value="<?= $eid ?>" <?= $eid === $selectedEmployeeId ? 'selected' : '' ?>>
-                  <?= s(($e['last_name'] ?? '') . ', ' . ($e['first_name'] ?? '') . " (ID: $eid)") ?>
-                </option>
-              <?php endforeach; ?>
-            </select>
-          </div>
-          <div class="col-auto">
-            <button type="submit" class="btn btn-primary">Load</button>
+            <input type="search" id="employeeSearch" class="form-control" placeholder="Type to search..." list="employeeList" autocomplete="off">
+            <datalist id="employeeList"></datalist>
+            <input type="hidden" id="employee_id" name="employee_id" value="<?= $selectedEmployeeId ?: '' ?>">
           </div>
           <div class="col-auto">
             <button type="button" class="btn btn.success btn-success" id="btnAdd">Add Window</button>
@@ -206,8 +159,9 @@ if ($selectedEmployeeId <= 0 && isset($employees[0]['employee_id'])) {
     const alertBox = document.getElementById('alertBox');
     const rowTpl = document.getElementById('rowTpl');
 
-    const employeeSelect = document.getElementById('employee_id');
-    const pickerForm = document.getElementById('employeePicker');
+    const employeeInput = document.getElementById('employeeSearch');
+    const employeeIdField = document.getElementById('employee_id');
+    const suggestionList = document.getElementById('employeeList');
     const btnAdd = document.getElementById('btnAdd');
 
     const winModalEl = document.getElementById('winModal');
@@ -219,6 +173,29 @@ if ($selectedEmployeeId <= 0 && isset($employees[0]['employee_id'])) {
     const winStart = document.getElementById('win_start');
     const winEnd = document.getElementById('win_end');
 
+    employeeInput.addEventListener('input', async () => {
+      const q = employeeInput.value.trim();
+      if (q.length < 2) { suggestionList.innerHTML = ''; return; }
+      const res = await fetch(`api/employees/search.php?q=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      suggestionList.innerHTML = '';
+      for (const it of data) {
+        const opt = document.createElement('option');
+        opt.value = `${it.name} (ID: ${it.id})`;
+        suggestionList.appendChild(opt);
+      }
+    });
+
+    employeeInput.addEventListener('change', () => {
+      const m = /\(ID:\s*(\d+)\)$/.exec(employeeInput.value);
+      if (m) {
+        employeeIdField.value = m[1];
+        loadAvailability();
+      } else {
+        employeeIdField.value = '';
+      }
+    });
+
     function showAlert(kind, msg) {
       alertBox.className = 'alert alert-' + kind;
       alertBox.textContent = msg;
@@ -227,7 +204,7 @@ if ($selectedEmployeeId <= 0 && isset($employees[0]['employee_id'])) {
     }
 
     function currentEmployeeId() {
-      return parseInt(employeeSelect.value || '0', 10) || 0;
+      return parseInt(employeeIdField.value || '0', 10) || 0;
     }
 
     async function loadAvailability() {
@@ -334,9 +311,19 @@ if ($selectedEmployeeId <= 0 && isset($employees[0]['employee_id'])) {
     });
 
     document.getElementById('btnAdd').addEventListener('click', openAdd);
-    document.getElementById('employeePicker').addEventListener('submit', (e) => { e.preventDefault(); loadAvailability(); });
 
-    loadAvailability();
+    const initId = currentEmployeeId();
+    if (initId) {
+      fetch(`api/employees/search.php?id=${initId}`)
+        .then(r => r.json())
+        .then(emp => {
+          if (emp && emp.name) employeeInput.value = `${emp.name} (ID: ${emp.id})`;
+          loadAvailability();
+        })
+        .catch(() => loadAvailability());
+    } else {
+      loadAvailability();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace employee dropdown with AJAX search
- add API endpoint for employee search
- auto-load availability for selected employee

## Testing
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a10a9f49ec832f891694ef97370217