### PR TITLE
Display full customer addresses

### DIFF
--- a/models/CustomerDataProvider.php
+++ b/models/CustomerDataProvider.php
@@ -13,8 +13,11 @@ final class CustomerDataProvider
      *   email:?string,
      *   phone:?string,
      *   address_line1:?string,
+     *   address_line2:?string,
      *   city:?string,
-     *   state:?string
+     *   state:?string,
+     *   postal_code:?string,
+     *   country:?string
      * }>
      */
     public static function getFiltered(
@@ -26,7 +29,7 @@ final class CustomerDataProvider
         ?string $sort = 'id',
         string $order = 'asc'
     ): array {
-        $sql = "SELECT id, first_name, last_name, email, phone, address_line1, city, state
+        $sql = "SELECT id, first_name, last_name, email, phone, address_line1, address_line2, city, state, postal_code, country
                 FROM customers
                 WHERE 1=1";
         $params = [];
@@ -38,7 +41,11 @@ final class CustomerDataProvider
                 'last_name',
                 'email',
                 'address_line1',
+                'address_line2',
                 'city',
+                'state',
+                'postal_code',
+                'country',
             ];
             $like = "%{$search}%";
             foreach ($searchFields as $i => $field) {
@@ -62,11 +69,13 @@ final class CustomerDataProvider
 
         // Determine sort column and direction
         $allowedSorts = [
-            'id'    => 'id',
-            'email' => 'email',
-            'phone' => 'phone',
-            'city'  => 'city',
-            'state' => 'state',
+            'id'          => 'id',
+            'email'       => 'email',
+            'phone'       => 'phone',
+            'city'        => 'city',
+            'state'       => 'state',
+            'postal_code' => 'postal_code',
+            'country'     => 'country',
         ];
         $sort = strtolower((string)$sort);
         $order = strtolower($order) === 'desc' ? 'DESC' : 'ASC';
@@ -90,8 +99,9 @@ final class CustomerDataProvider
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
 
-        /** @var array<int, array{id:int, first_name:string, last_name:string, email:?string, phone:?string, address_line1:?string, city:?string, state:?string}> */
+        /** @var array<int, array{id:int, first_name:string, last_name:string, email:?string, phone:?string, address_line1:?string, address_line2:?string, city:?string, state:?string, postal_code:?string, country:?string}> */
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         return $rows;
     }
 }
+

--- a/public/customers.php
+++ b/public/customers.php
@@ -68,7 +68,7 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
             <th><?= sort_link('Phone', 'phone', $baseParams, $sort, $dir) ?></th>
             <th><?= sort_link('City', 'city', $baseParams, $sort, $dir) ?></th>
             <th><?= sort_link('State', 'state', $baseParams, $sort, $dir) ?></th>
-            <th>Short Address</th>
+            <th>Address</th>
             <th class="text-end">Actions</th>
           </tr>
         </thead>
@@ -81,7 +81,18 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
             <td><?= s($r['phone'] ?? '') ?></td>
             <td><?= s($r['city'] ?? '') ?></td>
             <td><?= s($r['state'] ?? '') ?></td>
-            <td><?= s(trim(($r['city'] ?? '') . ', ' . ($r['state'] ?? ''), ' ,')) ?></td>
+            <td><?php
+              $parts = [
+                  $r['address_line1'] ?? null,
+                  $r['address_line2'] ?? null,
+                  $r['city'] ?? null,
+                  $r['state'] ?? null,
+                  $r['postal_code'] ?? null,
+                  $r['country'] ?? null,
+              ];
+              $parts = array_filter($parts, fn($v) => $v !== null && $v !== '');
+              echo s(implode(', ', $parts));
+            ?></td>
             <td class="text-end">
               <a href="/customer_form.php?id=<?= (int)$r['id'] ?>" class="btn btn-sm btn-outline-secondary">Edit</a>
             </td>

--- a/tests/Unit/CustomerDataProviderSortTest.php
+++ b/tests/Unit/CustomerDataProviderSortTest.php
@@ -18,8 +18,11 @@ final class CustomerDataProviderSortTest extends TestCase
             email TEXT,
             phone TEXT,
             address_line1 TEXT,
+            address_line2 TEXT,
             city TEXT,
-            state TEXT
+            state TEXT,
+            postal_code TEXT,
+            country TEXT
         )');
         $pdo->exec("INSERT INTO customers (id, first_name, last_name) VALUES
             (1,'John','Zulu'),


### PR DESCRIPTION
## Summary
- extend customer data provider to include address line 2, postal code, and country and allow sorting by these fields
- show a formatted full address on the customer listing page
- update unit tests for the expanded customer schema

## Testing
- `make unit`
- `make test` *(fails: DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a111a783ac832fab49f946f3fbfba4