### PR TITLE
Add phone mask to customer form

### DIFF
--- a/public/customer_form.php
+++ b/public/customer_form.php
@@ -108,6 +108,24 @@ function sticky(string $name, ?string $default = null): string {
         latitude: 'latitude',
         longitude: 'longitude'
       });
+      const phoneEl = document.getElementById('phone');
+      if (phoneEl) {
+        phoneEl.addEventListener('input', function (e) {
+          const digits = e.target.value.replace(/\D/g, '').slice(0, 10);
+          let formatted = digits;
+          if (digits.length > 6) {
+            formatted = '(' + digits.slice(0, 3) + ') ' + digits.slice(3, 6) + '-' + digits.slice(6);
+          } else if (digits.length > 3) {
+            formatted = '(' + digits.slice(0, 3) + ') ' + digits.slice(3);
+          } else if (digits.length > 0) {
+            formatted = '(' + digits;
+          }
+          e.target.value = formatted;
+          const valid = digits.length === 10;
+          e.target.classList.toggle('is-invalid', !valid);
+          e.target.setCustomValidity(valid ? '' : 'Invalid phone number');
+        });
+      }
     });
     (function () {
       const forms = document.querySelectorAll('.needs-validation');


### PR DESCRIPTION
## Summary
- add phone input masking and validity checks to customer form

## Testing
- `vendor/bin/phpunit` (fails: SQLSTATE[HY000] [2002] Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a113bb2508832f88a11b28234f02d4