### PR TITLE
Link customer edit button to dedicated page

### DIFF
--- a/public/customers.php
+++ b/public/customers.php
@@ -94,7 +94,7 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
               echo s(implode(', ', $parts));
             ?></td>
             <td class="text-end">
-              <a href="/customer_form.php?id=<?= (int)$r['id'] ?>" class="btn btn-sm btn-outline-secondary">Edit</a>
+              <a href="/edit_customer.php?id=<?= (int)$r['id'] ?>" class="btn btn-sm btn-outline-secondary">Edit</a>
             </td>
           </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- Open `edit_customer.php` when clicking Edit on the customers list

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a11b8accac832f9a7814435d450759