### PR TITLE
Add created_at sorting and display for customers

### DIFF
--- a/models/CustomerDataProvider.php
+++ b/models/CustomerDataProvider.php
@@ -19,7 +19,8 @@ final class CustomerDataProvider
      *   city:?string,
      *   state:?string,
      *   postal_code:?string,
-     *   country:?string
+     *   country:?string,
+     *   created_at:string
      * }>
      */
     public static function getFiltered(
@@ -31,7 +32,7 @@ final class CustomerDataProvider
         ?string $sort = 'id',
         string $order = 'asc'
     ): array {
-        $sql = "SELECT id, first_name, last_name, company, notes, email, phone, address_line1, address_line2, city, state, postal_code, country
+        $sql = "SELECT id, first_name, last_name, company, notes, email, phone, address_line1, address_line2, city, state, postal_code, country, created_at
                 FROM customers
                 WHERE 1=1";
         $params = [];
@@ -81,6 +82,7 @@ final class CustomerDataProvider
             'state'       => 'state',
             'postal_code' => 'postal_code',
             'country'     => 'country',
+            'created_at'  => 'created_at',
         ];
         $sort = strtolower((string)$sort);
         $order = strtolower($order) === 'desc' ? 'DESC' : 'ASC';
@@ -104,7 +106,7 @@ final class CustomerDataProvider
         $stmt = $pdo->prepare($sql);
         $stmt->execute($params);
 
-        /** @var array<int, array{id:int, first_name:string, last_name:string, company:?string, notes:?string, email:?string, phone:?string, address_line1:?string, address_line2:?string, city:?string, state:?string, postal_code:?string, country:?string}> */
+        /** @var array<int, array{id:int, first_name:string, last_name:string, company:?string, notes:?string, email:?string, phone:?string, address_line1:?string, address_line2:?string, city:?string, state:?string, postal_code:?string, country:?string, created_at:string}> */
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
         return $rows;
     }

--- a/public/customers.php
+++ b/public/customers.php
@@ -69,6 +69,7 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
             <th><?= sort_link('Phone', 'phone', $baseParams, $sort, $dir) ?></th>
             <th><?= sort_link('City', 'city', $baseParams, $sort, $dir) ?></th>
             <th><?= sort_link('State', 'state', $baseParams, $sort, $dir) ?></th>
+            <th><?= sort_link('Created', 'created_at', $baseParams, $sort, $dir) ?></th>
             <th>Address</th>
             <th class="text-end">Actions</th>
           </tr>
@@ -83,6 +84,7 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
             <td><?= s($r['phone'] ?? '') ?></td>
             <td><?= s($r['city'] ?? '') ?></td>
             <td><?= s($r['state'] ?? '') ?></td>
+            <td><?php $created = $r['created_at'] ? date('Y-m-d H:i', strtotime($r['created_at'])) : ''; echo s($created); ?></td>
             <td><?php
               $parts = [
                   $r['address_line1'] ?? null,
@@ -101,7 +103,7 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
           </tr>
         <?php endforeach; ?>
         <?php if (!$rows): ?>
-          <tr><td colspan="9" class="text-center text-muted py-4">No customers found.</td></tr>
+          <tr><td colspan="10" class="text-center text-muted py-4">No customers found.</td></tr>
         <?php endif; ?>
         </tbody>
       </table>

--- a/tests/Unit/CustomerDataProviderSortTest.php
+++ b/tests/Unit/CustomerDataProviderSortTest.php
@@ -24,7 +24,8 @@ final class CustomerDataProviderSortTest extends TestCase
             city TEXT,
             state TEXT,
             postal_code TEXT,
-            country TEXT
+            country TEXT,
+            created_at TEXT
         )');
         $pdo->exec("INSERT INTO customers (id, first_name, last_name) VALUES
             (1,'John','Zulu'),
@@ -38,5 +39,47 @@ final class CustomerDataProviderSortTest extends TestCase
         $rowsDesc = CustomerDataProvider::getFiltered($pdo, null, null, null, null, 'name', 'desc');
         $lastDesc = array_column($rowsDesc, 'last_name');
         $this->assertSame(['Zulu', 'Mike', 'Alpha'], $lastDesc);
+    }
+
+    public function testSortsByCreatedAtAscendingAndDescending(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE customers (
+            id INTEGER PRIMARY KEY,
+            first_name TEXT,
+            last_name TEXT,
+            company TEXT,
+            notes TEXT,
+            email TEXT,
+            phone TEXT,
+            address_line1 TEXT,
+            address_line2 TEXT,
+            city TEXT,
+            state TEXT,
+            postal_code TEXT,
+            country TEXT,
+            created_at TEXT
+        )');
+
+        $pdo->exec("INSERT INTO customers (id, created_at) VALUES
+            (1, '2024-01-01 10:00:00'),
+            (2, '2024-01-02 10:00:00'),
+            (3, '2024-01-03 10:00:00')");
+
+        $rowsAsc = CustomerDataProvider::getFiltered($pdo, null, null, null, null, 'created_at', 'asc');
+        $datesAsc = array_column($rowsAsc, 'created_at');
+        $this->assertSame([
+            '2024-01-01 10:00:00',
+            '2024-01-02 10:00:00',
+            '2024-01-03 10:00:00',
+        ], $datesAsc);
+
+        $rowsDesc = CustomerDataProvider::getFiltered($pdo, null, null, null, null, 'created_at', 'desc');
+        $datesDesc = array_column($rowsDesc, 'created_at');
+        $this->assertSame([
+            '2024-01-03 10:00:00',
+            '2024-01-02 10:00:00',
+            '2024-01-01 10:00:00',
+        ], $datesDesc);
     }
 }


### PR DESCRIPTION
## Summary
- include `created_at` in customer data provider and allow sorting
- show formatted Created column on customers page
- test sorting by creation date

## Testing
- `make unit`
- `make lint` (fails: Found 84 errors)
- `make integration` (fails: DB connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a122b4a734832fafa80f5681a53287