### PR TITLE
Log database errors in employee search endpoint

### DIFF
--- a/public/api/employees/search.php
+++ b/public/api/employees/search.php
@@ -46,8 +46,9 @@ try {
     }
     echo json_encode($rows, JSON_UNESCAPED_SLASHES);
 } catch (Throwable $e) {
+    error_log($e->getMessage());
     http_response_code(500);
-    echo json_encode([]);
+    echo json_encode(['error' => 'Database unavailable']);
 
     exit;
 


### PR DESCRIPTION
## Summary
- log exceptions in employee search endpoint
- return structured JSON error when database unavailable

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68a122f24d38832fab1059a690bbb4c2