### PR TITLE
Restrict job creation to dispatchers

### DIFF
--- a/public/add_job.php
+++ b/public/add_job.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 require __DIR__ . '/_cli_guard.php';
+if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
+$role = ($_SESSION['role'] ?? '') ?: ($_SESSION['user']['role'] ?? '');
+if ($role !== 'dispatcher') { http_response_code(403); echo "Forbidden"; exit; }
 
 $mode       = 'add';
 $job        = [];


### PR DESCRIPTION
## Summary
- require dispatcher role before showing add job form

## Testing
- `vendor/bin/phpunit` (DB connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a127f344b8832fafd5406f271e6c32