### PR TITLE
Expose job skills in job API response

### DIFF
--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -137,6 +137,9 @@ try {
                 'address_line1' => (string)$r['address_line1'],
                 'city' => (string)$r['city'],
             ],
+            // Include required job skills; provide both legacy and current keys
+            // so older clients expecting `skills` still receive data.
+            'skills' => $skills,
             'job_skills' => $skills,
             'assigned_employees' => $emps,
             'status' => (string)$r['status'],

--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -59,9 +59,13 @@
         tr.appendChild(custCell);
         // Job skills
         const jsCell=document.createElement('td');
-        const skills = job.skills?.length ? job.skills : job.job_skills;
-        if(skills?.length){
-          jsCell.innerHTML=skills.map(s=>`<span class="badge bg-secondary-subtle text-secondary border me-1">${h(s.name)}</span>`).join('');
+        const skills = Array.isArray(job.skills) && job.skills.length
+            ? job.skills
+            : Array.isArray(job.job_skills) ? job.job_skills : [];
+        if(skills.length){
+          jsCell.innerHTML=skills
+            .map(s=>`<span class="badge bg-secondary-subtle text-secondary border me-1">${h(s.name)}</span>`)
+            .join('');
         } else {
           jsCell.textContent='—';
         }


### PR DESCRIPTION
## Summary
- Return required job skills from the jobs API under both `skills` and `job_skills`
- Render job skills in the jobs table by supporting both field names

## Testing
- `make lint` *(fails: missingType.iterableValue and other errors)*
- `make test` *(fails: PDOException DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a12cb464fc832f98ed2e4ba480cce0