### PR TITLE
Handle employee search errors and clean up modal focus

### DIFF
--- a/public/api/employees/search.php
+++ b/public/api/employees/search.php
@@ -46,10 +46,9 @@ try {
     }
     echo json_encode($rows, JSON_UNESCAPED_SLASHES);
 } catch (Throwable $e) {
+    // On any DB error return an empty result set instead of a 500 error
     error_log($e->getMessage());
-    http_response_code(500);
-    echo json_encode(['error' => 'Database unavailable']);
-
+    http_response_code(200);
+    echo json_encode($id > 0 ? new stdClass() : []);
     exit;
-
 }

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -121,7 +121,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
       <form class="modal-content" id="winForm">
         <div class="modal-header">
           <h5 class="modal-title" id="winTitle">Add Window</h5>
-          <button type="button" class="btn btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body row g-3">
           <input type="hidden" name="id" id="win_id">
@@ -215,6 +215,14 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
     const winEndDate = document.getElementById('win_end_date');
     const btnWeekdays = document.getElementById('btnWeekdays');
     const btnClearWeek = document.getElementById('btnClearWeek');
+
+    // Clear focus inside the modal before it is hidden to avoid accessibility warnings
+    winModalEl.addEventListener('hide.bs.modal', () => {
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && winModalEl.contains(active)) {
+        active.blur();
+      }
+    });
 
     function toggleRecurring() {
       const hide = winRecurring.checked;


### PR DESCRIPTION
## Summary
- Return empty results instead of 500 error when employee search DB call fails
- Avoid accessibility warning by blurring focused modal elements before hide and using correct close button markup

## Testing
- `make test` *(fails: DB connection refused)*
- `make lint` *(fails: Found 84 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a12e966e04832fb9f330da9092c65a