### PR TITLE
Fix job save validation handling and error display

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -48,7 +48,10 @@
             return;
           }
           var errs=[];
-          if(data && data.errors){ errs=data.errors; }
+          if(data && data.errors){
+            if(Array.isArray(data.errors)){ errs=data.errors; }
+            else if(typeof data.errors==='object'){ errs=Object.values(data.errors); }
+          }
           else if(data && data.error){ errs=[data.error]; }
           else { errs=['Unknown error']; }
           showErrors(errs);


### PR DESCRIPTION
## Summary
- return field-specific error messages and action type from job_save.php
- ensure job_form.js handles structured error responses

## Testing
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a12f5f8114832fa06e9d7a9094a2d2