### PR TITLE
Link jobs directly to skills and update matching

### DIFF
--- a/models/AssignmentEngine.php
+++ b/models/AssignmentEngine.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/Job.php';
 /**
  * AssignmentEngine — eligibility + helpers
  * Drop-in ready for weekday names OR numbers in employee_availability.day_of_week
@@ -34,7 +35,10 @@ class AssignmentEngine
         $endTs   = $startTs + ($duration * 60);
 
         // Required skills for this job
-        $requiredSkillIds = array_map('intval', JobType::getRequiredSkillsForJob($this->pdo, $jobId));
+        $requiredSkillIds = array_map(
+            static fn(array $r): int => (int)$r['id'],
+            Job::getSkillsForJob($this->pdo, $jobId)
+        );
 
         // Candidates: active techs
         $candSql = "SELECT e.id AS employee_id, p.first_name, p.last_name, p.latitude AS emp_lat, p.longitude AS emp_lng

--- a/models/Job.php
+++ b/models/Job.php
@@ -87,4 +87,34 @@ final class Job
             return [];
         }
     }
+
+    /**
+     * Fetch skills linked to a job (id + name).
+     *
+     * @return list<array{id:int,name:string}>
+     */
+    public static function getSkillsForJob(PDO $pdo, int $jobId): array
+    {
+        try {
+            $st = $pdo->prepare("
+                SELECT s.id, s.name
+                FROM job_skill js
+                JOIN skills s ON s.id = js.skill_id
+                WHERE js.job_id = :job_id
+                ORDER BY s.name, s.id
+            ");
+            if ($st === false) {
+                return [];
+            }
+            $st->execute([':job_id' => $jobId]);
+            /** @var list<array{id:int|string,name:string}> $rows */
+            $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+            return array_map(
+                static fn(array $r): array => ['id' => (int)$r['id'], 'name' => (string)$r['name']],
+                $rows
+            );
+        } catch (Throwable $e) {
+            return [];
+        }
+    }
 }

--- a/public/add_job.php
+++ b/public/add_job.php
@@ -7,6 +7,6 @@ if ($role !== 'dispatcher') { http_response_code(403); echo "Forbidden"; exit; }
 
 $mode       = 'add';
 $job        = [];
-$jobTypeIds = [];
+$jobSkillIds = [];
 
 require __DIR__ . '/job_form.php';

--- a/public/api/assignments/eligible.php
+++ b/public/api/assignments/eligible.php
@@ -72,10 +72,8 @@ $schema = [
   'employee_availability'   => tableExists($pdo,'employee_availability'),
   'employee_availability_overrides' => tableExists($pdo, 'employee_availability_overrides'),
   'employee_skills'         => tableExists($pdo,'employee_skills'),
-  'job_types'               => tableExists($pdo,'job_types'),
+  'job_skill'               => tableExists($pdo,'job_skill'),
   'skills'                  => tableExists($pdo,'skills'),
-  'job_jobtype'             => tableExists($pdo,'job_jobtype'),
-  'jobtype_skills'          => tableExists($pdo,'jobtype_skills'),
   'job_employee_assignment' => tableExists($pdo,'job_employee_assignment'),
   'job_employee'            => tableExists($pdo,'job_employee'),
 ];
@@ -125,13 +123,12 @@ $jobWindowLabel = sprintf('%s, %s—%s', $dtLocal->format('Y-m-d'), $dtLocal->fo
 
 /* -------------- Required skills for job -------------- */
 $reqIds = []; $reqNamesById = [];
-if ($schema['job_jobtype'] && $schema['jobtype_skills'] && $schema['skills']) {
+if ($schema['job_skill'] && $schema['skills']) {
   $stReq = $pdo->prepare(
-    "SELECT DISTINCT s.id, s.name
-       FROM job_jobtype jj
-       JOIN jobtype_skills jts ON jts.job_type_id = jj.job_type_id
-       JOIN skills s ON s.id = jts.skill_id
-       WHERE jj.job_id = :jid
+    "SELECT s.id, s.name
+       FROM job_skill js
+       JOIN skills s ON s.id = js.skill_id
+       WHERE js.job_id = :jid
        ORDER BY s.name"
   );
   $stReq->execute([':jid' => $jobId]);

--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 // /public/api/jobs.php
 require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobType.php';
+require __DIR__ . '/../../models/Job.php';
 
 header('Content-Type: application/json');
 
@@ -73,9 +73,9 @@ try {
     foreach ($rows as $r) {
         $jobId = (int)$r['id'];
 
-        // Required job skills for this job derived from its job type(s)
-        $skills = JobType::getRequiredSkillsForJob($pdo, $jobId);
-        $skills = array_map(fn($n) => ['name' => $n], $skills);
+        // Required job skills for this job
+        $skillRows = Job::getSkillsForJob($pdo, $jobId);
+        $skills = array_map(static fn($r) => ['name' => $r['name']], $skillRows);
 
         // Use distinct placeholders for each occurrence when native prepares are enabled
         // to avoid "Invalid parameter number" errors with drivers that don't allow

--- a/public/edit_job.php
+++ b/public/edit_job.php
@@ -8,8 +8,8 @@ require_once __DIR__ . '/../models/Job.php';
 $pdo = getPDO();
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $job = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
-$jobTypes = $id > 0 ? Job::getJobTypesForJob($pdo, $id) : [];
-$jobTypeIds = array_map(static fn(array $r): string => (string)$r['id'], $jobTypes);
+$skills = $id > 0 ? Job::getSkillsForJob($pdo, $id) : [];
+$jobSkillIds = array_map(static fn(array $r): string => (string)$r['id'], $skills);
 
 $mode = 'edit';
 

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 require __DIR__ . '/_cli_guard.php';
 require_once __DIR__ . '/../config/database.php';
 require_once __DIR__ . '/_csrf.php';
-require_once __DIR__ . '/../models/JobType.php';
+require_once __DIR__ . '/../models/Skill.php';
 require_once __DIR__ . '/../models/Job.php';
 require_once __DIR__ . '/../models/Customer.php';
 
@@ -13,10 +13,10 @@ $__csrf = csrf_token();
 
 $mode        = $mode ?? 'add';
 $job         = $job ?? [];
-$jobTypeIds  = $jobTypeIds ?? [];
+$jobSkillIds = $jobSkillIds ?? [];
 $isEdit      = $mode === 'edit';
 
-$jobTypes  = JobType::all($pdo);
+$skills   = Skill::all($pdo);
 $statuses  = $isEdit ? Job::allowedStatuses() : array_intersect(['scheduled','draft'], Job::allowedStatuses());
 $customers = (new Customer($pdo))->getAll();
 $today     = date('Y-m-d');
@@ -85,20 +85,20 @@ function stickyArr(string $name, array $default = []): array {
           <div class="invalid-feedback">Description must be between 5 and 255 characters.</div>
         </div>
         <div class="mb-3">
-          <span class="form-label d-block mb-2">Job Types</span>
-          <?php $selJt = stickyArr('job_types', array_map('strval', $jobTypeIds)); ?>
-          <div class="row row-cols-2" id="jobTypes">
-            <?php foreach ($jobTypes as $jt): ?>
-              <?php $jid = (string)$jt['id']; ?>
+          <span class="form-label d-block mb-2">Skills</span>
+          <?php $selSkills = stickyArr('skills', array_map('strval', $jobSkillIds)); ?>
+          <div class="row row-cols-2" id="skills">
+            <?php foreach ($skills as $sk): ?>
+              <?php $sid = (string)$sk['id']; ?>
               <div class="col">
                 <div class="form-check">
-                  <input class="form-check-input" type="checkbox" name="job_types[]" value="<?= s($jid) ?>" id="jt<?= s($jid) ?>" <?= in_array($jid, $selJt, true) ? 'checked' : '' ?>>
-                  <label class="form-check-label" for="jt<?= s($jid) ?>"><?= s($jt['name']) ?></label>
+                  <input class="form-check-input" type="checkbox" name="skills[]" value="<?= s($sid) ?>" id="sk<?= s($sid) ?>" <?= in_array($sid, $selSkills, true) ? 'checked' : '' ?>>
+                  <label class="form-check-label" for="sk<?= s($sid) ?>"><?= s($sk['name']) ?></label>
                 </div>
               </div>
             <?php endforeach; ?>
           </div>
-          <div class="invalid-feedback d-block" id="jobTypeError" style="display:none">Select at least one job type.</div>
+          <div class="invalid-feedback d-block" id="jobSkillError" style="display:none">Select at least one skill.</div>
         </div>
         <div class="mb-3">
           <label for="status" class="form-label">Status <span class="text-danger">*</span></label>

--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -5,7 +5,7 @@
     var mode = form.getAttribute('data-mode') || 'add';
     var errBox = document.getElementById('form-errors');
     var customerSelect = document.getElementById('customerId');
-    var jtError = document.getElementById('jobTypeError');
+    var skillError = document.getElementById('jobSkillError');
 
     function showErrors(list){
       if(!errBox) return;
@@ -31,9 +31,9 @@
     form.addEventListener('submit', function(e){
       e.preventDefault();
       showErrors([]);
-      var jtChecks = form.querySelectorAll('input[name="job_types[]"]:checked');
+      var skillChecks = form.querySelectorAll('input[name="skills[]"]:checked');
       var valid = form.checkValidity();
-      if(jtChecks.length===0){ if(jtError){jtError.style.display='block';} valid=false; } else { if(jtError){jtError.style.display='none';} }
+      if(skillChecks.length===0){ if(skillError){skillError.style.display='block';} valid=false; } else { if(skillError){skillError.style.display='none';} }
       if(!valid){ form.classList.add('was-validated'); return; }
       var submitBtn=form.querySelector('button[type="submit"]');
       var originalHTML = submitBtn ? submitBtn.innerHTML : '';

--- a/tests/Integration/JobWriteRbacTest.php
+++ b/tests/Integration/JobWriteRbacTest.php
@@ -33,6 +33,7 @@ final class JobWriteRbacTest extends TestCase
             'scheduled_date' => '2025-08-20',
             'scheduled_time' => '10:00',
             'status'         => 'scheduled',
+            'skills'         => [1],
         ], [
             'role' => 'field_tech',
         ]);
@@ -52,6 +53,7 @@ final class JobWriteRbacTest extends TestCase
             'scheduled_date' => '2025-08-20',
             'scheduled_time' => '10:00',
             'status'         => 'scheduled',
+            'skills'         => [1],
             // no csrf_token on purpose
         ], [
             'role' => 'dispatcher',
@@ -73,6 +75,7 @@ final class JobWriteRbacTest extends TestCase
             'scheduled_time'   => '09:30',
             'status'           => 'scheduled',
             'duration_minutes' => 120,
+            'skills'           => [1],
         ], ['role' => 'dispatcher']);
 
         $this->assertTrue($create['ok'] ?? false);
@@ -90,6 +93,7 @@ final class JobWriteRbacTest extends TestCase
             'scheduled_time'   => '14:15',
             'status'           => 'assigned',
             'duration_minutes' => 90,
+            'skills'           => [1],
         ], ['role' => 'dispatcher']);
 
         $this->assertTrue($update['ok'] ?? false);


### PR DESCRIPTION
## Summary
- add `Job::getSkillsForJob` and persist job-skill mappings
- replace job type checkboxes with skill checkboxes and validation
- adjust job API and assignment engine to pull skills from `job_skill`

## Testing
- `make unit`
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a135a6aaa8832f845cd8a2ccaab890