### PR TITLE
Add availability audit logging with change log viewer

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -194,6 +194,22 @@ if (!tableExists($pdo, 'employee_availability_overrides')) {
     out('[OK] employee_availability_overrides created');
 }
 
+
+if (!tableExists($pdo, 'availability_audit')) {
+    out('[..] Creating table availability_audit ...');
+    $pdo->exec(
+        "CREATE TABLE `availability_audit` (
+            `id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            `employee_id` INT NOT NULL,
+            `user_id` INT NULL,
+            `action` VARCHAR(50) NOT NULL,
+            `details` TEXT NULL,
+            `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] availability_audit created');
+}
+
 if (!tableExists($pdo, 'skills')) {
     out('[..] Creating table skills ...');
     $pdo->exec(
@@ -260,7 +276,7 @@ if (tableExists($pdo, 'customers')) {
 }
 
 out("== Ensuring PRIMARY KEYS ==");
-foreach (['people','employees','job_types','employee_availability_overrides'] as $t) {
+foreach (['people','employees','job_types','employee_availability_overrides','availability_audit'] as $t) {
     ensureAutoPk($pdo, $t);
 }
 
@@ -280,6 +296,7 @@ ensureFk($pdo, 'job_employee_assignment', 'job_id', 'jobs', 'id', 'fk_jea_job', 
 ensureFk($pdo, 'job_employee_assignment', 'employee_id', 'employees', 'id', 'fk_jea_employee', 'RESTRICT', 'RESTRICT');
 
 ensureFk($pdo, 'employee_availability_overrides', 'employee_id', 'employees', 'id', 'fk_eao_employee', 'CASCADE', 'CASCADE');
+ensureFk($pdo, 'availability_audit', 'employee_id', 'employees', 'id', 'fk_avail_audit_employee', 'CASCADE', 'CASCADE');
 
 out(PHP_EOL . "== Ensuring UNIQUE indexes ==");
 ensureUnique($pdo, 'employee_availability', ['employee_id','day_of_week','start_time','end_time'], 'uq_availability_window');

--- a/public/api/availability/create.php
+++ b/public/api/availability/create.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../../../config/database.php';
+if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 
 $pdo = getPDO();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -53,5 +54,15 @@ if ($id > 0) {
     $id = (int)$pdo->lastInsertId();
 }
 
+
+try {
+    $uid = $_SESSION['user']['id'] ?? null;
+    $det = json_encode(['id'=>$id,'day'=>$day,'start'=>$start,'end'=>$end], JSON_UNESCAPED_UNICODE);
+    $act = $id > 0 ? 'update' : 'create';
+    $pdo->prepare('INSERT INTO availability_audit (employee_id, user_id, action, details) VALUES (:eid,:uid,:act,:det)')
+        ->execute([':eid'=>$eid, ':uid'=>$uid, ':act'=>$act, ':det'=>$det]);
+} catch (Throwable $e) {
+    // ignore audit errors
+}
 echo json_encode(['ok'=>true,'id'=>$id]);
 

--- a/public/api/availability/override.php
+++ b/public/api/availability/override.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../../../config/database.php';
+if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 
 $pdo = getPDO();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -64,6 +65,16 @@ if ($id > 0) {
     $id = (int)$pdo->lastInsertId();
 }
 
+
+try {
+    $uid = $_SESSION['user']['id'] ?? null;
+    $det = json_encode(['id'=>$id,'date'=>$date,'status'=>$status,'start'=>$start,'end'=>$end,'reason'=>$reason], JSON_UNESCAPED_UNICODE);
+    $act = $id > 0 ? 'override_update' : 'override_create';
+    $pdo->prepare('INSERT INTO availability_audit (employee_id, user_id, action, details) VALUES (:eid,:uid,:act,:det)')
+        ->execute([':eid'=>$eid, ':uid'=>$uid, ':act'=>$act, ':det'=>$det]);
+} catch (Throwable $e) {
+    // ignore audit errors
+}
 $resp = ['ok'=>true,'id'=>$id];
 if ($warning) $resp['warning'] = $warning;
 echo json_encode($resp);

--- a/public/api/availability/override_delete.php
+++ b/public/api/availability/override_delete.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../../../config/database.php';
+if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 
 $pdo = getPDO();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -19,8 +20,21 @@ if ($id <= 0) {
     exit;
 }
 
+$eidRow = $pdo->prepare('SELECT employee_id FROM employee_availability_overrides WHERE id = :id');
+$eidRow->execute([':id'=>$id]);
+$empId = (int)$eidRow->fetchColumn();
+
 $st = $pdo->prepare('DELETE FROM employee_availability_overrides WHERE id = :id');
 $st->execute([':id'=>$id]);
 
+
+try {
+    $uid = $_SESSION['user']['id'] ?? null;
+    $det = json_encode(['id'=>$id], JSON_UNESCAPED_UNICODE);
+    $pdo->prepare('INSERT INTO availability_audit (employee_id, user_id, action, details) VALUES (:eid, :uid, :act, :det)')
+        ->execute([':eid'=>$empId, ':uid'=>$uid, ':act'=>'override_delete', ':det'=>$det]);
+} catch (Throwable $e) {
+    // ignore audit errors
+}
 echo json_encode(['ok'=>true,'deleted'=>$st->rowCount()]);
 

--- a/public/availability_save.php
+++ b/public/availability_save.php
@@ -83,6 +83,14 @@ try {
     ");
     $ins->execute([':eid'=>$employeeId, ':dow'=>$day, ':st'=>$start, ':et'=>$end]);
     $newId = (int)$pdo->lastInsertId();
+    try {
+        $uid = $_SESSION['user']['id'] ?? null;
+        $det = json_encode(['id'=>$newId,'day'=>$day,'start'=>$start,'end'=>$end], JSON_UNESCAPED_UNICODE);
+        $pdo->prepare('INSERT INTO availability_audit (employee_id, user_id, action, details) VALUES (:eid,:uid,:act,:det)')
+            ->execute([':eid'=>$employeeId, ':uid'=>$uid, ':act'=>'create', ':det'=>$det]);
+    } catch (Throwable $e) {
+        // ignore audit errors
+    }
     json_out(['ok'=>true,'id'=>$newId]);
 } catch (Throwable $e) {
     error_log('[availability_save] ' . $e->getMessage());

--- a/public/availability_update.php
+++ b/public/availability_update.php
@@ -92,6 +92,14 @@ try {
     $ok = $up->execute([
         ':eid'=>$employeeId, ':dow'=>$day, ':st'=>$start, ':et'=>$end, ':id'=>$id
     ]);
+    try {
+        $uid = $_SESSION['user']['id'] ?? null;
+        $det = json_encode(['id'=>$id,'day'=>$day,'start'=>$start,'end'=>$end], JSON_UNESCAPED_UNICODE);
+        $pdo->prepare('INSERT INTO availability_audit (employee_id, user_id, action, details) VALUES (:eid,:uid,:act,:det)')
+            ->execute([':eid'=>$employeeId, ':uid'=>$uid, ':act'=>'update', ':det'=>$det]);
+    } catch (Throwable $e) {
+        // ignore audit errors
+    }
     json_out(['ok'=> (bool)$ok, 'id'=>$id]);
 } catch (Throwable $e) {
     error_log('[availability_update] ' . $e->getMessage());


### PR DESCRIPTION
## Summary
- create `availability_audit` table and ensure schema checks
- log availability create, update, delete and override actions
- add Change Log button to Availability Manager with log endpoint

## Testing
- `php -l bin/ensure_core_schema.php`
- `php -l public/api/availability/create.php`
- `php -l public/api/availability/override.php`
- `php -l public/api/availability/override_delete.php`
- `php -l public/availability_save.php`
- `php -l public/availability_update.php`
- `php -l public/availability_delete.php`
- `php -l public/availability_process.php`
- `php -l public/availability_manager.php`
- `./vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a1386a6cf4832f9af3969c611dc7ef