### PR TITLE
Add availability export and print support

### DIFF
--- a/public/api/availability/export.php
+++ b/public/api/availability/export.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * GET /api/availability/export.php
+ * Output CSV of recurring availability and overrides for an employee and week.
+ * Params: employee_id (int), week_start (Y-m-d)
+ */
+
+require_once __DIR__ . '/../../../config/database.php';
+
+$pdo = getPDO();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$eid = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 0;
+$weekStart = isset($_GET['week_start']) ? (string)$_GET['week_start'] : '';
+
+if ($eid <= 0 || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $weekStart)) {
+    http_response_code(400);
+    echo 'invalid_params';
+    exit;
+}
+
+$ws = new DateTimeImmutable($weekStart);
+$we = $ws->modify('+6 days')->format('Y-m-d');
+
+// Employee name
+$stEmp = $pdo->prepare("SELECT CONCAT(first_name,' ',last_name) AS name FROM employees WHERE id = :id");
+$stEmp->execute([':id' => $eid]);
+$empName = (string)$stEmp->fetchColumn();
+if ($empName === '') {
+    http_response_code(404);
+    echo 'not_found';
+    exit;
+}
+
+// Recurring availability
+$dayOrderSql = "FIELD(day_of_week,'Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday')";
+$st = $pdo->prepare("SELECT day_of_week, DATE_FORMAT(start_time,'%H:%i') AS start_time, DATE_FORMAT(end_time,'%H:%i') AS end_time FROM employee_availability WHERE employee_id=:eid ORDER BY {$dayOrderSql}, start_time");
+$st->execute([':eid' => $eid]);
+$avail = $st->fetchAll(PDO::FETCH_ASSOC);
+
+// Overrides within week range
+$st2 = $pdo->prepare("SELECT date, DATE_FORMAT(start_time,'%H:%i') AS start_time, DATE_FORMAT(end_time,'%H:%i') AS end_time, status, reason FROM employee_availability_overrides WHERE employee_id=:eid AND date BETWEEN :ws AND :we ORDER BY date, start_time");
+$st2->execute([':eid' => $eid, ':ws' => $ws->format('Y-m-d'), ':we' => $we]);
+$overrides = $st2->fetchAll(PDO::FETCH_ASSOC);
+
+// CSV helper
+$esc = static function (?string $v): string {
+    $v = (string)$v;
+    $v = str_replace(['"', "\n", "\r"], ['""', ' ', ' '], $v);
+    return '"' . $v . '"';
+};
+
+$lines = ['employee,day,start,end,status,reason'];
+foreach ($avail as $a) {
+    $lines[] = implode(',', [
+        $esc($empName),
+        $esc($a['day_of_week'] ?? ''),
+        $esc($a['start_time'] ?? ''),
+        $esc($a['end_time'] ?? ''),
+        $esc(''),
+        $esc(''),
+    ]);
+}
+
+foreach ($overrides as $ov) {
+    $lines[] = implode(',', [
+        $esc($empName),
+        $esc($ov['date'] ?? ''),
+        $esc($ov['start_time'] ?? ''),
+        $esc($ov['end_time'] ?? ''),
+        $esc($ov['status'] ?? ''),
+        $esc($ov['reason'] ?? ''),
+    ]);
+}
+
+header('Content-Type: text/csv');
+header('Content-Disposition: attachment; filename="availability.csv"');
+echo implode("\n", $lines);

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -84,6 +84,8 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
           <div class="col-auto">
             <button type="button" class="btn btn-success" id="btnAdd">Add Window</button>
             <button type="button" class="btn btn-warning ms-2" id="btnAddOverride">Add Override</button>
+            <button type="button" class="btn btn-outline-info ms-2" id="btnExport">Export</button>
+            <button type="button" class="btn btn-outline-secondary ms-2" id="btnPrint">Print</button>
           </div>
         </form>
       </div>
@@ -291,6 +293,8 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
     const resultSelect = document.getElementById('employeeResults');
     const btnAdd = document.getElementById('btnAdd');
     const btnAddOverride = document.getElementById('btnAddOverride');
+    const btnExport = document.getElementById('btnExport');
+    const btnPrint = document.getElementById('btnPrint');
 
     const winModalEl = document.getElementById('winModal');
     const winModal = new bootstrap.Modal(winModalEl);
@@ -673,6 +677,18 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
 
     document.getElementById('btnAdd').addEventListener('click', openAdd);
     btnAddOverride.addEventListener('click', openOvAdd);
+    btnExport.addEventListener('click', () => {
+      const eid = currentEmployeeId();
+      if (!eid) { showAlert('warning', 'Select an employee first.'); return; }
+      const ws = currentWeekStart();
+      window.location.href = `api/availability/export.php?employee_id=${encodeURIComponent(eid)}&week_start=${ws}`;
+    });
+    btnPrint.addEventListener('click', () => {
+      const eid = currentEmployeeId();
+      if (!eid) { showAlert('warning', 'Select an employee first.'); return; }
+      const ws = currentWeekStart();
+      window.open(`availability_print.php?employee_id=${encodeURIComponent(eid)}&week_start=${ws}`, '_blank');
+    });
 
     const initId = currentEmployeeId();
     if (initId) {

--- a/public/availability_print.php
+++ b/public/availability_print.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
+require_once __DIR__ . '/../config/database.php';
+
+$pdo = getPDO();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$eid = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 0;
+$weekStart = isset($_GET['week_start']) ? (string)$_GET['week_start'] : '';
+
+if ($eid <= 0 || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $weekStart)) {
+    http_response_code(400);
+    echo 'Invalid parameters';
+    exit;
+}
+
+$ws = new DateTimeImmutable($weekStart);
+$we = $ws->modify('+6 days')->format('Y-m-d');
+
+$stEmp = $pdo->prepare("SELECT CONCAT(first_name,' ',last_name) AS name FROM employees WHERE id = :id");
+$stEmp->execute([':id'=>$eid]);
+$empName = (string)$stEmp->fetchColumn();
+if ($empName === '') {
+    http_response_code(404);
+    echo 'Employee not found';
+    exit;
+}
+
+$dayOrderSql = "FIELD(day_of_week,'Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday')";
+$st = $pdo->prepare("SELECT day_of_week, DATE_FORMAT(start_time,'%H:%i') AS start_time, DATE_FORMAT(end_time,'%H:%i') AS end_time FROM employee_availability WHERE employee_id=:eid ORDER BY {$dayOrderSql}, start_time");
+$st->execute([':eid'=>$eid]);
+$avail = $st->fetchAll(PDO::FETCH_ASSOC);
+
+$st2 = $pdo->prepare("SELECT date, DATE_FORMAT(start_time,'%H:%i') AS start_time, DATE_FORMAT(end_time,'%H:%i') AS end_time, status, reason FROM employee_availability_overrides WHERE employee_id=:eid AND date BETWEEN :ws AND :we ORDER BY date, start_time");
+$st2->execute([':eid'=>$eid, ':ws'=>$ws->format('Y-m-d'), ':we'=>$we]);
+$overrides = $st2->fetchAll(PDO::FETCH_ASSOC);
+?>
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Availability Print</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+<style>body{padding:20px;}@media print{.no-print{display:none}}</style>
+</head>
+<body>
+<div class="container">
+  <h1 class="h4 mb-4">Availability for <?= htmlspecialchars($empName, ENT_QUOTES, 'UTF-8') ?></h1>
+  <table class="table table-bordered">
+    <thead>
+      <tr><th>Day</th><th>Start</th><th>End</th><th>Status</th><th>Reason</th></tr>
+    </thead>
+    <tbody>
+    <?php foreach ($avail as $a): ?>
+      <tr>
+        <td><?= htmlspecialchars((string)$a['day_of_week'], ENT_QUOTES, 'UTF-8') ?></td>
+        <td><?= htmlspecialchars((string)$a['start_time'], ENT_QUOTES, 'UTF-8') ?></td>
+        <td><?= htmlspecialchars((string)$a['end_time'], ENT_QUOTES, 'UTF-8') ?></td>
+        <td></td>
+        <td></td>
+      </tr>
+    <?php endforeach; ?>
+    <?php foreach ($overrides as $ov): ?>
+      <tr>
+        <td><?= htmlspecialchars((string)$ov['date'], ENT_QUOTES, 'UTF-8') ?></td>
+        <td><?= htmlspecialchars((string)($ov['start_time'] ?? ''), ENT_QUOTES, 'UTF-8') ?></td>
+        <td><?= htmlspecialchars((string)($ov['end_time'] ?? ''), ENT_QUOTES, 'UTF-8') ?></td>
+        <td><?= htmlspecialchars((string)($ov['status'] ?? ''), ENT_QUOTES, 'UTF-8') ?></td>
+        <td><?= htmlspecialchars((string)($ov['reason'] ?? ''), ENT_QUOTES, 'UTF-8') ?></td>
+      </tr>
+    <?php endforeach; ?>
+    </tbody>
+  </table>
+  <button class="btn btn-primary no-print" onclick="window.print()">Print</button>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add API to export an employee's weekly availability and overrides to CSV
- provide printable availability view
- expose Export and Print buttons on availability manager

## Testing
- `php -l public/api/availability/export.php`
- `php -l public/availability_print.php`
- `php -l public/availability_manager.php`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a1386e457c832f8790afd03c66912f