### PR TITLE
Add job type selections and persistence

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -262,6 +262,30 @@ if (!tableExists($pdo, 'jobtype_skills')) {
     out('[OK] jobtype_skills created');
 }
 
+// Ensure job_skill table
+if (!tableExists($pdo, 'job_skill')) {
+    out('[..] Creating table job_skill ...');
+    $pdo->exec(
+        "CREATE TABLE `job_skill` (
+            `job_id` INT NOT NULL,
+            `skill_id` INT NOT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] job_skill created');
+}
+
+// Ensure job_jobtype table
+if (!tableExists($pdo, 'job_jobtype')) {
+    out('[..] Creating table job_jobtype ...');
+    $pdo->exec(
+        "CREATE TABLE `job_jobtype` (
+            `job_id` INT NOT NULL,
+            `job_type_id` INT NOT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] job_jobtype created');
+}
+
 // Ensure optional columns on existing tables
 if (tableExists($pdo, 'customers')) {
     $cols = columns($pdo, 'customers');
@@ -292,6 +316,12 @@ ensureFk($pdo, 'employee_skills', 'skill_id', 'skills', 'id', 'fk_es_skill', 'RE
 ensureFk($pdo, 'jobtype_skills', 'job_type_id', 'job_types', 'id', 'fk_jobtype_skills_jobtype', 'RESTRICT', 'CASCADE');
 ensureFk($pdo, 'jobtype_skills', 'skill_id', 'skills', 'id', 'fk_jobtype_skills_skill', 'RESTRICT', 'CASCADE');
 
+ensureFk($pdo, 'job_skill', 'job_id', 'jobs', 'id', 'fk_job_skill_job', 'CASCADE', 'RESTRICT');
+ensureFk($pdo, 'job_skill', 'skill_id', 'skills', 'id', 'fk_job_skill_skill', 'RESTRICT', 'CASCADE');
+
+ensureFk($pdo, 'job_jobtype', 'job_id', 'jobs', 'id', 'fk_job_jobtype_job', 'CASCADE', 'RESTRICT');
+ensureFk($pdo, 'job_jobtype', 'job_type_id', 'job_types', 'id', 'fk_job_jobtype_type', 'RESTRICT', 'CASCADE');
+
 ensureFk($pdo, 'job_employee_assignment', 'job_id', 'jobs', 'id', 'fk_jea_job', 'CASCADE', 'RESTRICT');
 ensureFk($pdo, 'job_employee_assignment', 'employee_id', 'employees', 'id', 'fk_jea_employee', 'RESTRICT', 'RESTRICT');
 
@@ -302,6 +332,8 @@ out(PHP_EOL . "== Ensuring UNIQUE indexes ==");
 ensureUnique($pdo, 'employee_availability', ['employee_id','day_of_week','start_time','end_time'], 'uq_availability_window');
 ensureUnique($pdo, 'employee_skills', ['employee_id','skill_id'], 'uq_employee_skill');
 ensureUnique($pdo, 'jobtype_skills', ['job_type_id','skill_id'], 'uq_jobtype_skill');
+ensureUnique($pdo, 'job_skill', ['job_id','skill_id'], 'uq_job_skill');
+ensureUnique($pdo, 'job_jobtype', ['job_id','job_type_id'], 'uq_job_jobtype');
 
 out(PHP_EOL . "== Cleaning obvious orphan rows (dev only) ==");
 try {

--- a/public/add_job.php
+++ b/public/add_job.php
@@ -8,5 +8,6 @@ if ($role !== 'dispatcher') { http_response_code(403); echo "Forbidden"; exit; }
 $mode       = 'add';
 $job        = [];
 $jobSkillIds = [];
+$jobTypeIds  = [];
 
 require __DIR__ . '/job_form.php';

--- a/public/edit_job.php
+++ b/public/edit_job.php
@@ -9,7 +9,9 @@ $pdo = getPDO();
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 $job = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
 $skills = $id > 0 ? Job::getSkillsForJob($pdo, $id) : [];
+$types  = $id > 0 ? Job::getJobTypesForJob($pdo, $id) : [];
 $jobSkillIds = array_map(static fn(array $r): string => (string)$r['id'], $skills);
+$jobTypeIds  = array_map(static fn(array $r): string => (string)$r['id'], $types);
 
 $mode = 'edit';
 

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/_csrf.php';
 require_once __DIR__ . '/../models/Skill.php';
 require_once __DIR__ . '/../models/Job.php';
 require_once __DIR__ . '/../models/Customer.php';
+require_once __DIR__ . '/../models/JobType.php';
 
 $pdo = getPDO();
 $__csrf = csrf_token();
@@ -14,9 +15,11 @@ $__csrf = csrf_token();
 $mode        = $mode ?? 'add';
 $job         = $job ?? [];
 $jobSkillIds = $jobSkillIds ?? [];
+$jobTypeIds  = $jobTypeIds  ?? [];
 $isEdit      = $mode === 'edit';
 
-$skills   = Skill::all($pdo);
+$skills    = Skill::all($pdo);
+$jobTypes  = JobType::all($pdo);
 $statuses  = $isEdit ? Job::allowedStatuses() : array_intersect(['scheduled','draft'], Job::allowedStatuses());
 $customers = (new Customer($pdo))->getAll();
 $today     = date('Y-m-d');
@@ -83,6 +86,22 @@ function stickyArr(string $name, array $default = []): array {
           <label for="description" class="form-label">Job Description <span class="text-danger">*</span></label>
           <textarea id="description" name="description" class="form-control" minlength="5" maxlength="255" required aria-required="true"><?= s(sticky('description', $job['description'] ?? '')) ?></textarea>
           <div class="invalid-feedback">Description must be between 5 and 255 characters.</div>
+        </div>
+        <div class="mb-3">
+          <span class="form-label d-block mb-2">Job Types</span>
+          <?php $selTypes = stickyArr('job_types', array_map('strval', $jobTypeIds)); ?>
+          <div class="row row-cols-2" id="jobTypes">
+            <?php foreach ($jobTypes as $jt): ?>
+              <?php $tid = (string)$jt['id']; ?>
+              <div class="col">
+                <div class="form-check">
+                  <input class="form-check-input" type="checkbox" name="job_types[]" value="<?= s($tid) ?>" id="jt<?= s($tid) ?>" <?= in_array($tid, $selTypes, true) ? 'checked' : '' ?>>
+                  <label class="form-check-label" for="jt<?= s($tid) ?>"><?= s($jt['name']) ?></label>
+                </div>
+              </div>
+            <?php endforeach; ?>
+          </div>
+          <div class="invalid-feedback d-block" id="jobTypeError" style="display:none">Select at least one job type.</div>
         </div>
         <div class="mb-3">
           <span class="form-label d-block mb-2">Skills</span>

--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -6,6 +6,7 @@
     var errBox = document.getElementById('form-errors');
     var customerSelect = document.getElementById('customerId');
     var skillError = document.getElementById('jobSkillError');
+    var jobTypeError = document.getElementById('jobTypeError');
 
     function showErrors(list){
       if(!errBox) return;
@@ -32,8 +33,10 @@
       e.preventDefault();
       showErrors([]);
       var skillChecks = form.querySelectorAll('input[name="skills[]"]:checked');
+      var typeChecks = form.querySelectorAll('input[name="job_types[]"]:checked');
       var valid = form.checkValidity();
       if(skillChecks.length===0){ if(skillError){skillError.style.display='block';} valid=false; } else { if(skillError){skillError.style.display='none';} }
+      if(typeChecks.length===0){ if(jobTypeError){jobTypeError.style.display='block';} valid=false; } else { if(jobTypeError){jobTypeError.style.display='none';} }
       if(!valid){ form.classList.add('was-validated'); return; }
       var submitBtn=form.querySelector('button[type="submit"]');
       var originalHTML = submitBtn ? submitBtn.innerHTML : '';


### PR DESCRIPTION
## Summary
- Display available job types on job form and require at least one selection
- Persist job type relationships and remove silent mapping errors
- Include job_skill and job_jobtype tables with FK and unique constraints

## Testing
- `vendor/bin/phpunit` *(fails: DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a42b7c6c832fa3c2e0872ac3564b