### PR TITLE
Improve employee search error handling

### DIFF
--- a/public/api/employees/search.php
+++ b/public/api/employees/search.php
@@ -26,29 +26,34 @@ try {
         $st = $pdo->prepare($sql);
         $st->execute([':id'=>$id]);
         $row = $st->fetch(PDO::FETCH_ASSOC);
-        echo json_encode($row ? ['id'=>(int)$row['id'], 'name'=>$row['name']] : new stdClass(), JSON_UNESCAPED_SLASHES);
+        echo json_encode(['ok' => true, 'item' => $row ? ['id'=>(int)$row['id'], 'name'=>$row['name']] : null], JSON_UNESCAPED_SLASHES);
         exit;
     }
 
     if (strlen($q) < 2) {
-        echo json_encode([]);
+        echo json_encode(['ok'=>true,'items'=>[]], JSON_UNESCAPED_SLASHES);
         exit;
     }
 
-    $sql = "SELECT e.id, CONCAT(p.first_name,' ',p.last_name) AS name FROM employees e JOIN people p ON p.id=e.person_id WHERE p.first_name LIKE :q OR p.last_name LIKE :q";
+    $params = [':q' => '%'.$q.'%'];
+    $where  = "p.first_name LIKE :q OR p.last_name LIKE :q OR CONCAT(p.first_name,' ',p.last_name) LIKE :q";
+    if (ctype_digit($q)) {
+        $where .= " OR e.id = :eid";
+        $params[':eid'] = (int)$q;
+    }
+    $sql = "SELECT e.id, CONCAT(p.first_name,' ',p.last_name) AS name FROM employees e JOIN people p ON p.id=e.person_id WHERE {$where}";
     if ($hasIsActive) { $sql .= " AND e.is_active=1"; }
     $sql .= " ORDER BY p.last_name, p.first_name LIMIT 20";
     $st = $pdo->prepare($sql);
-    $st->execute([':q'=>'%'.$q.'%']);
+    $st->execute($params);
     $rows = [];
     foreach ($st->fetchAll(PDO::FETCH_ASSOC) as $r) {
         $rows[] = ['id'=>(int)$r['id'], 'name'=>$r['name']];
     }
-    echo json_encode($rows, JSON_UNESCAPED_SLASHES);
+    echo json_encode(['ok'=>true,'items'=>$rows], JSON_UNESCAPED_SLASHES);
 } catch (Throwable $e) {
-    // On any DB error return an empty result set instead of a 500 error
     error_log($e->getMessage());
     http_response_code(200);
-    echo json_encode($id > 0 ? new stdClass() : []);
+    echo json_encode(['ok'=>false,'error'=>'Database query failed'], JSON_UNESCAPED_SLASHES);
     exit;
 }


### PR DESCRIPTION
## Summary
- Surface API errors when searching for employees and alert on empty results or request failures
- Support multi-word and ID searches with error reporting on failures

## Testing
- `./vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a1acc00c00832fb0ac76102cd5cf85