### PR TITLE
Use utf8mb4 collation for search queries

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -71,6 +71,7 @@ if (!function_exists('getPDO')) {
                 PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                 PDO::ATTR_EMULATE_PREPARES   => false,
             ]);
+            $pdo->exec('SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci');
             return $pdo;
         } catch (PDOException $e) {
             // Helpful but not secret-spilling

--- a/public/api/employees/search.php
+++ b/public/api/employees/search.php
@@ -36,7 +36,10 @@ try {
     }
 
     $params = [':q' => '%'.$q.'%'];
-    $where  = "p.first_name LIKE :q OR p.last_name LIKE :q OR CONCAT(p.first_name,' ',p.last_name) LIKE :q";
+    $coll   = 'utf8mb4_unicode_ci';
+    $where  = "p.first_name COLLATE {$coll} LIKE :q"
+            . " OR p.last_name COLLATE {$coll} LIKE :q"
+            . " OR CONCAT(p.first_name,' ',p.last_name) COLLATE {$coll} LIKE :q";
     if (ctype_digit($q)) {
         $where .= " OR e.id = :eid";
         $params[':eid'] = (int)$q;


### PR DESCRIPTION
## Summary
- enforce utf8mb4_unicode_ci collation for employee search LIKE clauses
- set connection collation after establishing PDO

## Testing
- `make lint` *(fails: Found 89 errors)*
- `make test` *(fails: DB connection refused)*
- `php bin/ensure_core_schema.php` *(fails: DB connection refused)*
- `php -r 'parse_str("q=test", $_GET); include "public/api/employees/search.php";'` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c07099c4832f8439a1e7c2d00954