### PR TITLE
Improve winForm error handling and logging

### DIFF
--- a/public/api/availability/log_client_error.php
+++ b/public/api/availability/log_client_error.php
@@ -1,0 +1,30 @@
+<?php
+// /public/api/availability/log_client_error.php
+declare(strict_types=1);
+
+header('Content-Type: application/json');
+
+$raw = file_get_contents('php://input') ?: '';
+$in = json_decode($raw, true);
+if (!is_array($in)) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'invalid_json']);
+    exit;
+}
+$eid   = (int)($in['employee_id'] ?? 0);
+$name  = (string)($in['employee_name'] ?? '');
+$msg   = (string)($in['message'] ?? '');
+$stack = (string)($in['stack'] ?? '');
+
+$logLine = sprintf(
+    "[%s] eid=%d name=%s msg=%s stack=%s\n",
+    date('c'),
+    $eid,
+    $name,
+    $msg,
+    $stack
+);
+error_log($logLine, 3, __DIR__ . '/../../../logs/availability_error.log');
+
+echo json_encode(['ok' => true]);
+

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -845,11 +845,24 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
         const data = await res.json();
         ok = data && data.ok;
         if (!ok) {
-          const msg = (data && (data.message || data.error || (Array.isArray(data.errors) ? data.errors.join(', ') : data.errors))) || 'Save failed';
+          const msg = (data && data.message) ? data.message : 'Save failed';
           showAlert('danger', msg);
         }
       } catch (err) {
-        showAlert('danger', 'Save failed');
+        const msg = (err && err.message) ? err.message : 'Save failed';
+        showAlert('danger', msg);
+        const logPayload = {
+          employee_id: eid,
+          employee_name: currentEmployeeName(),
+          message: err && err.message ? err.message : '',
+          stack: err && err.stack ? err.stack : ''
+        };
+        fetch('api/availability/log_client_error.php', {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(logPayload)
+        }).catch(() => {});
       }
 
       if (ok) {


### PR DESCRIPTION
## Summary
- surface server `message` in winForm save failures
- log winForm exceptions with employee info
- add lightweight API endpoint to persist client error diagnostics

## Testing
- `make test` *(fails: DB connection refused)*
- `make lint` *(fails: Found 89 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec426548832f9971e5d060f9a669