### PR TITLE
Use APP_ENV to select integration test database

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -21,7 +21,8 @@ if (!function_exists('getPDO')) {
         $cfg = [
             'DB_HOST' => '127.0.0.1',
             'DB_PORT' => '8889',
-            'DB_NAME' => 'fieldops',
+            // Default to the integration DB when running in test env
+            'DB_NAME' => getenv('APP_ENV') === 'test' ? 'fieldops_integration' : 'fieldops',
             'DB_USER' => 'root',
             'DB_PASS' => 'root',
             'APP_ENV' => getenv('APP_ENV') ?: 'dev',

--- a/config/local.env.php
+++ b/config/local.env.php
@@ -3,6 +3,6 @@
 $APP_ENV = 'test';
 $DB_HOST = '127.0.0.1';
 $DB_PORT = '8889';
-$DB_NAME = 'fieldops_test';
+$DB_NAME = 'fieldops_integration';
 $DB_USER = 'root';
 $DB_PASS = 'root';

--- a/phpunit.xml.bak
+++ b/phpunit.xml.bak
@@ -20,7 +20,7 @@
     <!-- Test DB (MAMP defaults) -->
     <env name="DB_HOST" value="127.0.0.1"/>
     <env name="DB_PORT" value="8889"/>
-    <env name="DB_NAME" value="fieldops_test"/>
+    <env name="DB_NAME" value="fieldops_integration"/>
     <env name="DB_USER" value="root"/>
     <env name="DB_PASS" value="root"/>
 

--- a/phpunit.xmldelete
+++ b/phpunit.xmldelete
@@ -18,7 +18,7 @@ vendor/bin/phpunit --testdox
         <!-- Use a dedicated test DB -->
         <env name="DB_HOST" value="127.0.0.1"/>
         <env name="DB_PORT" value="8889"/>
-        <env name="DB_NAME" value="fieldops_test"/>
+        <env name="DB_NAME" value="fieldops_integration"/>
         <env name="DB_USER" value="root"/>
         <env name="DB_PASS" value="root"/>
 	<env name="BASE_URL" value="http://localhost:8888"/>

--- a/tests/Integration/AssignmentsDataTest.php
+++ b/tests/Integration/AssignmentsDataTest.php
@@ -10,20 +10,8 @@ final class AssignmentsDataTest extends TestCase
     protected function setUp(): void
     {
         // Build PDO from env (phpunit.xml)
-        $this->pdo = new PDO(
-            sprintf(
-                'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
-                getenv('DB_HOST') ?: '127.0.0.1',
-                getenv('DB_PORT') ?: '8889',
-                getenv('DB_NAME') ?: 'fieldops_test'
-            ),
-            getenv('DB_USER') ?: 'root',
-            getenv('DB_PASS') ?: 'root',
-            [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-            ]
-        );
+        require_once __DIR__ . '/../support/TestPdo.php';
+        $this->pdo = createTestPdo();
 
         // Start a transaction so we leave no residue
         $this->pdo->beginTransaction();

--- a/tests/Integration/DbSmokeTest.php
+++ b/tests/Integration/DbSmokeTest.php
@@ -8,20 +8,8 @@ final class DbSmokeTest extends TestCase
     public function testCanConnectAndSeeCoreTables(): void
     {
         // Recreate test PDO using env from phpunit.xml
-        $pdo = new PDO(
-            sprintf(
-                'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
-                getenv('DB_HOST') ?: '127.0.0.1',
-                getenv('DB_PORT') ?: '8889',
-                getenv('DB_NAME') ?: 'fieldops_test'
-            ),
-            getenv('DB_USER') ?: 'root',
-            getenv('DB_PASS') ?: 'root',
-            [
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
-            ]
-        );
+        require_once __DIR__ . '/../support/TestPdo.php';
+        $pdo = createTestPdo();
 
         $tables = [
             'customers',

--- a/tests/Integration/JobEmployeeViewTest.php
+++ b/tests/Integration/JobEmployeeViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('integration')]
 final class JobEmployeeViewTest extends TestCase
@@ -14,13 +15,7 @@ final class JobEmployeeViewTest extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         $this->pdo->exec('DELETE FROM job_employee_assignment');
         $this->pdo->exec('DELETE FROM jobs');

--- a/tests/JobsTableEdgeCasesTest.php
+++ b/tests/JobsTableEdgeCasesTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/support/TestPdo.php';
 
 #[Group('jobs')]
 final class JobsTableEdgeCasesTest extends TestCase
@@ -18,13 +19,7 @@ final class JobsTableEdgeCasesTest extends TestCase
 
         $this->baseUrl = rtrim(getenv('FIELDOPS_BASE_URL') ?: 'http://127.0.0.1:8010', '/');
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         // Clean DB
         $this->pdo->exec('DELETE FROM job_employee_assignment');

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ configure a database and seed it with minimal data so an active employee exists.
    return [
        'DB_HOST' => '127.0.0.1',
        'DB_PORT' => '3306',
-       'DB_NAME' => 'fieldops_test',
+       'DB_NAME' => 'fieldops_integration',
        'DB_USER' => 'root',
        'DB_PASS' => 'root',
    ];
@@ -25,9 +25,9 @@ configure a database and seed it with minimal data so an active employee exists.
 2. **Create the database schema**:
 
    ```bash
-   mysql -u root -p -e 'CREATE DATABASE fieldops_test;'
+   mysql -u root -p -e 'CREATE DATABASE fieldops_integration;'
    # Load your schema if necessary
-   mysql -u root -p fieldops_test < path/to/schema.sql
+   mysql -u root -p fieldops_integration < path/to/schema.sql
    ```
 
 3. **Seed an active employee** – many scripts (e.g. `tests/smoke.sh`) expect at least

--- a/tests/assignments/AssignmentsApiNegativeTest.php
+++ b/tests/assignments/AssignmentsApiNegativeTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('assignments')]
 final class AssignmentsApiNegativeTest extends TestCase
@@ -17,14 +18,7 @@ final class AssignmentsApiNegativeTest extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         // Clean DB for isolation
         $this->pdo->exec('DELETE FROM job_employee_assignment');

--- a/tests/assignments/AvailabilityOverrideTest.php
+++ b/tests/assignments/AvailabilityOverrideTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 require_once __DIR__ . '/../../models/AssignmentEngine.php';
 
 #[Group('assignments')]
@@ -18,14 +19,7 @@ final class AvailabilityOverrideTest extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         // Ensure overrides table exists for tests
         $this->pdo->exec("CREATE TABLE IF NOT EXISTS employee_availability_overrides (

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,11 @@ declare(strict_types=1);
  * - You can enable trace with FIELDOPS_TRACE=1 to see suppressed call stacks in error_log.
  */
 
+if (getenv('APP_ENV') === false) {
+    // Ensure config/database.php sees APP_ENV=test
+    putenv('APP_ENV=test');
+    $_ENV['APP_ENV'] = 'test';
+}
 if (!defined('APP_ENV')) {
     define('APP_ENV', 'test');
 }

--- a/tests/db_sanity_check.php
+++ b/tests/db_sanity_check.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 // Load env variables from phpunit.xml manually for CLI run
 $host = getenv('DB_HOST') ?: '127.0.0.1';
 $port = getenv('DB_PORT') ?: '8889';
-$db   = getenv('DB_NAME') ?: 'fieldops_test';
+$db   = getenv('DB_NAME') ?: 'fieldops_integration';
 $user = getenv('DB_USER') ?: 'root';
 $pass = getenv('DB_PASS') ?: 'root';
 

--- a/tests/db_sanity_check.php.save
+++ b/tests/db_sanity_check.php.save
@@ -48,7 +48,7 @@ declare(strict_types=1);
 // Load env variables from phpunit.xml manually for CLI run
 $host = getenv('DB_HOST') ?: '127.0.0.1';
 $port = getenv('DB_PORT') ?: '8889';
-$db   = getenv('DB_NAME') ?: 'fieldops_test';
+$db   = getenv('DB_NAME') ?: 'fieldops_integration';
 $user = getenv('DB_USER') ?: 'root';
 $pass = getenv('DB_PASS') ?: 'root';
 

--- a/tests/employees/EmployeesSaveControllerTest.php
+++ b/tests/employees/EmployeesSaveControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('employees')]
 final class EmployeesSaveControllerTest extends TestCase
@@ -19,14 +20,8 @@ final class EmployeesSaveControllerTest extends TestCase
         // Base URL for controller calls (server must be running with -t public)
         $this->baseUrl = rtrim(getenv('FIELDOPS_BASE_URL') ?: 'http://127.0.0.1:8010', '/');
 
-        // Test DB (MAMP-friendly default)
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        // Test DB connection
+        $this->pdo = createTestPdo();
 
         // Clean relevant tables
         $this->pdo->exec('DELETE FROM job_employee_assignment');

--- a/tests/jobs/JobsTableEdgeCasesTest.php
+++ b/tests/jobs/JobsTableEdgeCasesTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('jobs')]
 final class JobsTableEdgeCasesTest extends TestCase
@@ -15,13 +16,7 @@ final class JobsTableEdgeCasesTest extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         // Clean DB
         $this->pdo->exec('DELETE FROM job_employee_assignment');

--- a/tests/rbac/RbacAssignmentsApiV2Test.php
+++ b/tests/rbac/RbacAssignmentsApiV2Test.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('rbac')]
 final class RbacAssignmentsApiV2Test extends TestCase
@@ -18,13 +19,7 @@ final class RbacAssignmentsApiV2Test extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         $this->pdo->exec('DELETE FROM job_employee_assignment');
         $this->pdo->exec('DELETE FROM jobs');

--- a/tests/rbac/RbacAssignmentsTest.php
+++ b/tests/rbac/RbacAssignmentsTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('rbac')]
 final class RbacAssignmentsTest extends TestCase
@@ -18,13 +19,7 @@ final class RbacAssignmentsTest extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         $this->pdo->exec('DELETE FROM job_employee_assignment');
         $this->pdo->exec('DELETE FROM jobs');

--- a/tests/rbac/RbacStatusLocksTest.php
+++ b/tests/rbac/RbacStatusLocksTest.php
@@ -5,6 +5,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../support/Http.php';
 require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../support/TestPdo.php';
 
 #[Group('rbac')]
 final class RbacStatusLocksTest extends TestCase
@@ -19,13 +20,7 @@ final class RbacStatusLocksTest extends TestCase
     {
         parent::setUp();
 
-        $dsn  = getenv('FIELDOPS_TEST_DSN')  ?: 'mysql:host=127.0.0.1;port=8889;dbname=fieldops_test;charset=utf8mb4';
-        $user = getenv('FIELDOPS_TEST_USER') ?: 'root';
-        $pass = getenv('FIELDOPS_TEST_PASS') ?: 'root';
-        $this->pdo = new PDO($dsn, $user, $pass, [
-            PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        ]);
+        $this->pdo = createTestPdo();
 
         // Clean
         $this->pdo->exec('DELETE FROM job_employee_assignment');

--- a/tests/reset_test_data.php
+++ b/tests/reset_test_data.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 // Reset only the test DB
 $host = getenv('DB_HOST') ?: '127.0.0.1';
 $port = getenv('DB_PORT') ?: '8889';
-$db   = getenv('DB_NAME') ?: 'fieldops_test';
+$db   = getenv('DB_NAME') ?: 'fieldops_integration';
 $user = getenv('DB_USER') ?: 'root';
 $pass = getenv('DB_PASS') ?: 'root';
 

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -13,7 +13,7 @@ done
 
 # ---- start server
 LOG="/tmp/fo_server_${PORT}.log"
-$PHP -S 127.0.0.1:$PORT -t "$ROOT/public" >"$LOG" 2>&1 &
+APP_ENV=${APP_ENV:-test} $PHP -S 127.0.0.1:$PORT -t "$ROOT/public" >"$LOG" 2>&1 &
 SERVER_PID=$!
 trap 'kill $SERVER_PID >/dev/null 2>&1 || true' EXIT
 

--- a/tests/smoke_extended.sh
+++ b/tests/smoke_extended.sh
@@ -13,7 +13,7 @@ pick_free_port() {
 
 PORT="$(pick_free_port)"; [ -n "$PORT" ] || { echo "No free port found"; exit 1; }
 LOG="/tmp/fo_server_${PORT}.log"
-$PHP -S 127.0.0.1:$PORT -t "$ROOT/public" >"$LOG" 2>&1 &
+APP_ENV=${APP_ENV:-test} $PHP -S 127.0.0.1:$PORT -t "$ROOT/public" >"$LOG" 2>&1 &
 SERVER_PID=$!
 trap 'kill $SERVER_PID >/dev/null 2>&1 || true' EXIT
 

--- a/tests/support/TestPdo.php
+++ b/tests/support/TestPdo.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+function createTestPdo(): PDO {
+    $dsn = getenv('FIELDOPS_TEST_DSN') ?: sprintf(
+        'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
+        getenv('DB_HOST') ?: '127.0.0.1',
+        getenv('DB_PORT') ?: '8889',
+        getenv('DB_NAME') ?: 'fieldops_integration'
+    );
+    $user = getenv('FIELDOPS_TEST_USER') ?: getenv('DB_USER') ?: 'root';
+    $pass = getenv('FIELDOPS_TEST_PASS') ?: getenv('DB_PASS') ?: 'root';
+
+    return new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+}


### PR DESCRIPTION
## Summary
- Default to `fieldops_integration` when `APP_ENV=test`
- Ensure test bootstrap and smoke scripts set `APP_ENV=test`
- Introduce `createTestPdo()` helper and use env-driven DB names in tests and reset scripts

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f4bfb61c832fb1edeb757a5b5bc9