### PR TITLE
Run migrations for test database

### DIFF
--- a/scripts/migrate_test_db.php
+++ b/scripts/migrate_test_db.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Run outstanding schema migrations against the test database.
+ *
+ * This script can be executed directly or included from other scripts.
+ * When included, call migrateTestDb($pdo) with an existing PDO connection.
+ */
+
+/**
+ * Apply migrations in tests/migrations using the supplied PDO connection.
+ */
+function migrateTestDb(PDO $pdo): void
+{
+    // Ensure a migrations tracking table exists
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS migrations (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            filename VARCHAR(255) UNIQUE NOT NULL,
+            run_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
+
+    $dir = __DIR__ . '/../tests/migrations';
+    if (!is_dir($dir)) {
+        echo "⚠️  No migrations directory found at {$dir}.\n";
+        return;
+    }
+
+    $files = glob($dir . '/*.sql') ?: [];
+    sort($files);
+
+    foreach ($files as $file) {
+        $name = basename($file);
+        $stmt = $pdo->prepare('SELECT 1 FROM migrations WHERE filename = ?');
+        $stmt->execute([$name]);
+        if ($stmt->fetchColumn()) {
+            continue; // already run
+        }
+
+        $sql = file_get_contents($file);
+        if ($sql === false) {
+            throw new RuntimeException("Failed to read migration {$name}");
+        }
+
+        $pdo->exec($sql);
+        $stmt = $pdo->prepare('INSERT INTO migrations (filename) VALUES (?)');
+        $stmt->execute([$name]);
+        echo "Applied migration: {$name}\n";
+    }
+
+    echo "✅ Schema migrations complete.\n";
+}
+
+if (PHP_SAPI === 'cli' && basename(__FILE__) === basename($_SERVER['argv'][0])) {
+    $host = getenv('DB_HOST') ?: '127.0.0.1';
+    $port = getenv('DB_PORT') ?: '8889';
+    $db   = getenv('DB_NAME') ?: 'fieldops_integration';
+    $user = getenv('DB_USER') ?: 'root';
+    $pass = getenv('DB_PASS') ?: 'root';
+
+    $pdo = new PDO(
+        "mysql:host={$host};port={$port};dbname={$db};charset=utf8mb4",
+        $user,
+        $pass,
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]
+    );
+
+    migrateTestDb($pdo);
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,22 @@ configure a database and seed it with minimal data so an active employee exists.
 
 With these steps completed, scripts and tests should be able to locate an active employee
 record and execute successfully.
+
+## Resetting the test database
+
+Run the reset script to apply any pending schema migrations and clear out transient test
+data:
+
+```bash
+php tests/reset_test_data.php
+```
+
+The reset script calls `scripts/migrate_test_db.php` internally. If you need to run
+migrations without clearing data, invoke the migration script directly:
+
+```bash
+php scripts/migrate_test_db.php
+```
 =======
 # Tests
 

--- a/tests/reset_test_data.php
+++ b/tests/reset_test_data.php
@@ -18,6 +18,10 @@ $pdo = new PDO(
     ]
 );
 
+// Ensure schema is up to date before clearing data
+require_once __DIR__ . '/../scripts/migrate_test_db.php';
+migrateTestDb($pdo);
+
 // Wrap in a transaction for speed/safety
 $pdo->beginTransaction();
 


### PR DESCRIPTION
## Summary
- add script to apply SQL migrations to test database
- ensure test reset script runs migrations before seeding
- document migration and reset workflow in test README

## Testing
- `php -l scripts/migrate_test_db.php`
- `php -l tests/reset_test_data.php`
- `php scripts/migrate_test_db.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `php tests/reset_test_data.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f7dfeb9c832f8250656829ed553a