### PR TITLE
Add CI workflow with MySQL and PHPUnit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: fieldops_integration
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+      - name: Wait for MySQL
+        run: |
+          for i in {1..30}; do
+            mysqladmin ping -h 127.0.0.1 -P 3306 -uroot -proot && break
+            sleep 1
+          done
+      - name: Create database
+        run: mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE DATABASE IF NOT EXISTS fieldops_integration;"
+      - name: Run migrations
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: fieldops_integration
+          DB_USER: root
+          DB_PASS: root
+        run: php tests/migrate_test_data.php
+      - name: Reset test data
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: fieldops_integration
+          DB_USER: root
+          DB_PASS: root
+        run: php tests/reset_test_data.php
+      - name: Run PHPUnit
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_NAME: fieldops_integration
+          DB_USER: root
+          DB_PASS: root
+        run: vendor/bin/phpunit

--- a/tests/migrate_test_data.php
+++ b/tests/migrate_test_data.php
@@ -1,0 +1,112 @@
+<?php
+// tests/migrate_test_data.php
+// Creates minimal schema for running tests in CI
+
+declare(strict_types=1);
+
+$host = getenv('DB_HOST') ?: '127.0.0.1';
+$port = getenv('DB_PORT') ?: '3306';
+$db   = getenv('DB_NAME') ?: 'fieldops_integration';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: 'root';
+
+try {
+    $pdo = new PDO("mysql:host={$host};port={$port};dbname={$db};charset=utf8mb4", $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]);
+} catch (PDOException $e) {
+    fwrite(STDERR, "Connection failed: {$e->getMessage()}\n");
+    exit(1);
+}
+
+// Define schema
+$sql = [
+    "CREATE TABLE IF NOT EXISTS customers (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        first_name VARCHAR(100) NOT NULL,
+        last_name VARCHAR(100) NOT NULL,
+        phone VARCHAR(50) NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS people (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        first_name VARCHAR(100) NOT NULL,
+        last_name VARCHAR(100) NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS employees (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        person_id INT NOT NULL,
+        employment_type VARCHAR(50) NOT NULL,
+        hire_date DATE NOT NULL,
+        status VARCHAR(20) NOT NULL,
+        is_active TINYINT(1) NOT NULL DEFAULT 1
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS employee_availability (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        employee_id INT NOT NULL,
+        day_of_week TINYINT NOT NULL,
+        start_time TIME NOT NULL,
+        end_time TIME NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS jobs (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        customer_id INT NOT NULL,
+        description VARCHAR(255) NOT NULL,
+        status VARCHAR(20) NOT NULL,
+        scheduled_date DATE NOT NULL,
+        scheduled_time TIME NOT NULL,
+        duration_minutes INT NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS job_types (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS job_employee_assignment (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        job_id INT NOT NULL,
+        employee_id INT NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS job_employee (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        job_id INT NOT NULL,
+        employee_id INT NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS skills (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS job_skill (
+        job_id INT NOT NULL,
+        skill_id INT NOT NULL
+    ) ENGINE=InnoDB",
+
+    "CREATE TABLE IF NOT EXISTS employee_availability_overrides (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        employee_id INT NOT NULL,
+        date DATE NOT NULL,
+        status VARCHAR(20) NOT NULL,
+        start_time TIME NULL,
+        end_time TIME NULL,
+        reason VARCHAR(255) NULL
+    ) ENGINE=InnoDB"
+];
+
+foreach ($sql as $query) {
+    $pdo->exec($query);
+}
+
+// Seed minimal lookup data
+$pdo->exec("INSERT INTO skills (id, name) VALUES (1, 'General') ON DUPLICATE KEY UPDATE name=VALUES(name)");
+$pdo->exec("INSERT INTO job_types (id, name) VALUES (1, 'General') ON DUPLICATE KEY UPDATE name=VALUES(name)");
+
+echo "✅ Migration complete\n";


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow spinning up MySQL, running migrations, and executing PHPUnit
- create migration script for test schema with minimal tables and seed data

## Testing
- `php tests/migrate_test_data.php` *(fails: Connection refused)*
- `php tests/reset_test_data.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpunit` *(fails: DB connection refused for multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f900fdac832f93f12595958a3a09