### PR TITLE
Show NA when distance unavailable

### DIFF
--- a/public/assign.php
+++ b/public/assign.php
@@ -119,9 +119,9 @@ function rowHTML(emp, prechecked) {
   const skills = Array.isArray(emp.skills) && emp.skills.length
     ? `<div class="text-muted small">Skills: ${emp.skills.map(s=>s.name||s).join(', ')}</div>`
     : '';
-  const dist = (typeof emp.distanceKm === 'number')
-    ? `<span class="ms-2 badge text-bg-light border">${emp.distanceKm.toFixed(1)} km</span>`
-    : '';
+    const dist = (typeof emp.distanceKm === 'number')
+      ? `<span class="ms-2 badge text-bg-light border">${(emp.distanceKm * 0.621371).toFixed(1)} mi</span>`
+      : '<span class="ms-2 badge text-bg-light border">NA</span>';
   const checked = prechecked ? 'checked' : '';
   const win = emp.availability && emp.availability.window ? emp.availability.window : '';
   const conflict = (emp.conflicts && emp.conflicts.length) ? true : false;

--- a/public/js/assignments.js
+++ b/public/js/assignments.js
@@ -304,8 +304,9 @@
         load: ${Number(e.dayLoad || 0)}
       </span>`;
 
-    const km = e.distanceKm != null ? `${e.distanceKm} km` : '—';
-    const rightMeta = `<span class="text-muted">${km}</span>${dl}`;
+    const miles =
+      e.distanceKm != null ? (e.distanceKm * 0.621371).toFixed(1) + ' mi' : 'NA';
+    const rightMeta = `<span class="text-muted">${miles}</span>${dl}`;
 
     // checkbox rules
     const hasRisk = (!e.qualified) || av.status !== 'full' || conflicts.length > 0;


### PR DESCRIPTION
## Summary
- Display "NA" when distance cannot be calculated in assign modal and page
- Convert employee distance to miles before display

## Testing
- `vendor/bin/phpunit` *(fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a2305a2684832f8fe271a3cecea2c1