### PR TITLE
Document availability status computation and schedule badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# FieldOps
+
+FieldOps is a scheduling and job assignment application for service teams.
+
+## Employee Schedule Badges
+
+The employees view displays a badge describing each worker's schedule status. The badge is derived from availability and assigned jobs for the day:
+
+- **Available** – availability exists and no jobs overlap.
+- **Booked** – jobs fully consume all available time.
+- **Partially Booked** – some availability remains after scheduled jobs.
+- **No Hours** – no availability is defined for that day.
+
+These badges mirror the `status` and `summary` computed in `Availability::statusForEmployeesOnDate`.

--- a/models/Availability.php
+++ b/models/Availability.php
@@ -1,5 +1,20 @@
 <?php declare(strict_types=1);
 
+/**
+ * Utilities for querying employee availability and deriving schedule details.
+ *
+ * Status and summary information are computed by loading an employee's
+ * availability blocks for a given day and subtracting any jobs scheduled for
+ * that same period. The remaining free time determines both values:
+ *
+ * - "No Hours"         when no availability is defined.
+ * - "Booked"           when jobs consume all available time.
+ * - "Available"        when availability exists with no overlapping jobs.
+ * - "Partially Booked" when some, but not all, availability remains.
+ *
+ * The summary is a human-readable list of the free time ranges or "Off" when
+ * none are left.
+ */
 final class Availability
 {
     /**


### PR DESCRIPTION
## Summary
- clarify how availability status and summary are derived in `Availability`
- add README section describing employee schedule badges

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a243ef6630832f881b83a8c4dd8cde