### PR TITLE
Require start date for availability windows

### DIFF
--- a/public/api/availability/index.php
+++ b/public/api/availability/index.php
@@ -43,7 +43,21 @@ try {
         return $isInt;
     }
 
-    $st = $pdo->prepare("SELECT id, day_of_week, DATE_FORMAT(start_time,'%H:%i') AS start_time, DATE_FORMAT(end_time,'%H:%i') AS end_time FROM employee_availability WHERE employee_id = :eid ORDER BY day_of_week, start_time");
+    function has_start_date(PDO $pdo): bool {
+        static $has = null;
+        if ($has !== null) return $has;
+        try {
+            $row = $pdo->query("SHOW COLUMNS FROM employee_availability LIKE 'start_date'")
+                ->fetch(PDO::FETCH_ASSOC);
+            $has = $row !== false;
+        } catch (Throwable $e) {
+            $has = false;
+        }
+        return $has;
+    }
+
+    $sdSel = has_start_date($pdo) ? ", DATE_FORMAT(start_date,'%Y-%m-%d') AS start_date" : "";
+    $st = $pdo->prepare("SELECT id, day_of_week, DATE_FORMAT(start_time,'%H:%i') AS start_time, DATE_FORMAT(end_time,'%H:%i') AS end_time{$sdSel} FROM employee_availability WHERE employee_id = :eid ORDER BY day_of_week, start_time");
     $st->execute([':eid' => $eid]);
     $avail = $st->fetchAll(PDO::FETCH_ASSOC);
 

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -273,9 +273,9 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
               <label class="form-check-label" for="win_recurring">Recurring?</label>
             </div>
           </div>
-          <div class="col-6 date-range d-none">
-            <label class="form-label">Start Date</label>
-            <input type="date" class="form-control" id="win_start_date">
+          <div class="col-6">
+            <label class="form-label">Effective from</label>
+            <input type="date" class="form-control" id="win_start_date" required>
           </div>
           <div class="col-6 date-range d-none">
             <label class="form-label">End Date</label>

--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -299,7 +299,7 @@ function openAdd() {
   clearBlocks();
   addBlock('09:00', '17:00');
   winRecurring.checked = true;
-  winStartDate.value = '';
+  winStartDate.value = currentWeekStart();
   winEndDate.value = '';
   toggleRecurring();
   winModal.show();
@@ -319,7 +319,8 @@ function openEditDay(day) {
     addBlock('09:00', '17:00');
   }
   winRecurring.checked = true;
-  winStartDate.value = '';
+  let sd = arr[0] && arr[0].start_date ? arr[0].start_date : currentWeekStart();
+  winStartDate.value = sd;
   winEndDate.value = '';
   toggleRecurring();
   winModal.show();
@@ -388,15 +389,16 @@ winForm.addEventListener('submit', async (e) => {
   for (let i=0;i<blocks.length-1;i++) {
     if (blocks[i].end_time > blocks[i+1].start_time) { showAlert('warning','Blocks overlap or out of order.'); return; }
   }
+  if (!winStartDate.value) { showAlert('warning', 'Start date required.'); return; }
 
   const payload = {
     csrf_token: CSRF,
     employee_id: eid,
     day_of_week: days,
-    blocks
+    blocks,
+    start_date: winStartDate.value
   };
   if (!winRecurring.checked) {
-    if (winStartDate.value) payload.start_date = winStartDate.value;
     if (winEndDate.value) payload.end_date = winEndDate.value;
   }
   if (winReplaceIds.value) {

--- a/tests/support/TestDataFactory.php
+++ b/tests/support/TestDataFactory.php
@@ -3,6 +3,15 @@ declare(strict_types=1);
 
 final class TestDataFactory
 {
+    private static function hasColumn(PDO $pdo, string $table, string $column): bool
+    {
+        try {
+            $pdo->query("SELECT {$column} FROM {$table} LIMIT 0");
+            return true;
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
     public static function createCustomer(PDO $pdo, string $first = 'Test', string $last = 'Customer'): int
     {
         $stmt = $pdo->prepare("INSERT INTO customers (first_name, last_name, phone) VALUES (:fn,:ln,:ph)");
@@ -30,11 +39,25 @@ final class TestDataFactory
 
     public static function setAvailability(PDO $pdo, int $employeeId, int $dayOfWeek, string $start = '09:00:00', string $end = '17:00:00'): void
     {
-        $stmt = $pdo->prepare("
-            INSERT INTO employee_availability (employee_id, day_of_week, start_time, end_time)
-            VALUES (:e,:d,:s,:t)
-        ");
-        $stmt->execute([':e' => $employeeId, ':d' => $dayOfWeek, ':s' => $start, ':t' => $end]);
+        if (self::hasColumn($pdo, 'employee_availability', 'start_date')) {
+            $stmt = $pdo->prepare("
+                INSERT INTO employee_availability (employee_id, day_of_week, start_time, end_time, start_date)
+                VALUES (:e,:d,:s,:t,:sd)
+            ");
+            $stmt->execute([
+                ':e' => $employeeId,
+                ':d' => $dayOfWeek,
+                ':s' => $start,
+                ':t' => $end,
+                ':sd' => date('Y-m-d'),
+            ]);
+        } else {
+            $stmt = $pdo->prepare("
+                INSERT INTO employee_availability (employee_id, day_of_week, start_time, end_time)
+                VALUES (:e,:d,:s,:t)
+            ");
+            $stmt->execute([':e' => $employeeId, ':d' => $dayOfWeek, ':s' => $start, ':t' => $end]);
+        }
     }
 
     public static function createJob(PDO $pdo, int $customerId, string $desc, string $date, string $time, int $duration = 60, string $status = 'scheduled'): int


### PR DESCRIPTION
## Summary
- Always display an "Effective from" date when adding availability windows
- Prefill the start date with the current week's Monday and require it on save
- Persist start dates in API and include them when listing availability

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c2c26638832f923bd56267ce06db