### PR TITLE
Add job notes support with CRUD APIs

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -314,6 +314,22 @@ if (!tableExists($pdo, 'job_skill')) {
     out('[OK] job_skill created');
 }
 
+// Ensure job_notes table
+if (!tableExists($pdo, 'job_notes')) {
+    out('[..] Creating table job_notes ...');
+    $pdo->exec(
+        "CREATE TABLE `job_notes` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `job_id` INT NOT NULL,
+            `technician_id` INT NOT NULL,
+            `note` TEXT NOT NULL,
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] job_notes created');
+}
+
 // Drop deprecated job_jobtype table if present
 if (tableExists($pdo, 'job_jobtype')) {
     out('[..] Dropping table job_jobtype ...');
@@ -362,6 +378,9 @@ ensureFk($pdo, 'jobtype_skills', 'skill_id', 'skills', 'id', 'fk_jobtype_skills_
 
 ensureFk($pdo, 'job_skill', 'job_id', 'jobs', 'id', 'fk_job_skill_job', 'CASCADE', 'RESTRICT');
 ensureFk($pdo, 'job_skill', 'skill_id', 'skills', 'id', 'fk_job_skill_skill', 'RESTRICT', 'CASCADE');
+
+ensureFk($pdo, 'job_notes', 'job_id', 'jobs', 'id', 'fk_job_notes_job', 'CASCADE', 'RESTRICT');
+ensureFk($pdo, 'job_notes', 'technician_id', 'employees', 'id', 'fk_job_notes_technician', 'RESTRICT', 'RESTRICT');
 
 
 ensureFk($pdo, 'job_employee_assignment', 'job_id', 'jobs', 'id', 'fk_jea_job', 'CASCADE', 'RESTRICT');

--- a/models/JobNote.php
+++ b/models/JobNote.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+/**
+ * JobNote model provides CRUD helpers for notes associated with jobs.
+ */
+final class JobNote
+{
+    /**
+     * List notes for a given job.
+     * @return list<array<string,mixed>>
+     */
+    public static function listForJob(PDO $pdo, int $jobId): array
+    {
+        $st = $pdo->prepare(
+            'SELECT id, job_id, technician_id, note, created_at
+             FROM job_notes
+             WHERE job_id = :jid
+             ORDER BY created_at DESC, id DESC'
+        );
+        if ($st === false) {
+            return [];
+        }
+        $st->execute([':jid' => $jobId]);
+        /** @var list<array<string,mixed>> $rows */
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(
+            static fn(array $r): array => [
+                'id' => (int)$r['id'],
+                'job_id' => (int)$r['job_id'],
+                'technician_id' => (int)$r['technician_id'],
+                'note' => (string)$r['note'],
+                'created_at' => (string)$r['created_at'],
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Add a new note for a job. Returns inserted id.
+     */
+    public static function add(PDO $pdo, int $jobId, int $technicianId, string $note): int
+    {
+        $st = $pdo->prepare(
+            'INSERT INTO job_notes (job_id, technician_id, note) VALUES (:jid, :tid, :n)'
+        );
+        $st->execute([':jid' => $jobId, ':tid' => $technicianId, ':n' => $note]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Update an existing note's text. Returns true if a row was updated.
+     */
+    public static function update(PDO $pdo, int $id, string $note): bool
+    {
+        $st = $pdo->prepare('UPDATE job_notes SET note = :n WHERE id = :id');
+        $st->execute([':n' => $note, ':id' => $id]);
+        return $st->rowCount() > 0;
+    }
+
+    /**
+     * Delete a note by id. Returns true if a row was deleted.
+     */
+    public static function delete(PDO $pdo, int $id): bool
+    {
+        $st = $pdo->prepare('DELETE FROM job_notes WHERE id = :id');
+        $st->execute([':id' => $id]);
+        return $st->rowCount() > 0;
+    }
+}

--- a/public/api/get_job_details.php
+++ b/public/api/get_job_details.php
@@ -1,14 +1,16 @@
 <?php
 declare(strict_types=1);
 
-require_once __DIR__ . '/../config/database.php';
-require_once __DIR__ . '/../models/Job.php';
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/Job.php';
+require_once __DIR__ . '/../../models/JobNote.php';
 
 header('Content-Type: application/json');
 
 $pdo = getPDO();
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
-$row = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
+$row   = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
+$notes = $id > 0 ? JobNote::listForJob($pdo, $id) : [];
 
-echo json_encode(['ok' => (bool)$row, 'job' => $row], JSON_UNESCAPED_SLASHES);
+echo json_encode(['ok' => (bool)$row, 'job' => $row, 'notes' => $notes], JSON_UNESCAPED_SLASHES);

--- a/public/api/job_notes_add.php
+++ b/public/api/job_notes_add.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require __DIR__ . '/../../models/JobNote.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    JsonResponse::json(['ok' => false, 'error' => 'Method not allowed', 'code' => 405], 405);
+    return;
+}
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$jobId        = isset($data['job_id']) ? (int)$data['job_id'] : 0;
+$technicianId = isset($data['technician_id']) ? (int)$data['technician_id'] : 0;
+$note         = trim((string)($data['note'] ?? ''));
+
+if ($jobId <= 0 || $technicianId <= 0 || $note === '') {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing parameters', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $id  = JobNote::add($pdo, $jobId, $technicianId, $note);
+    JsonResponse::json(['ok' => true, 'id' => $id]);
+} catch (Throwable $e) {
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}

--- a/public/api/job_notes_list.php
+++ b/public/api/job_notes_list.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require __DIR__ . '/../../models/JobNote.php';
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
+if ($jobId <= 0) {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing job_id', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+try {
+    $pdo   = getPDO();
+    $notes = JobNote::listForJob($pdo, $jobId);
+    JsonResponse::json(['ok' => true, 'notes' => $notes]);
+} catch (Throwable $e) {
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}

--- a/tests/migrations/20241004120000_create_job_notes.sql
+++ b/tests/migrations/20241004120000_create_job_notes.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS job_notes (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    job_id INT NOT NULL,
+    technician_id INT NOT NULL,
+    note TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_job_notes_job_id (job_id),
+    CONSTRAINT fk_job_notes_job FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,
+    CONSTRAINT fk_job_notes_technician FOREIGN KEY (technician_id) REFERENCES employees(id) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- add `job_notes` table with schema and FKs
- create `JobNote` model and endpoints for adding and listing notes
- extend job details API to return related notes

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c2fd76ec832fb0e0d0b8499b09b3