### PR TITLE
Add job photo uploads and metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # Local API keys
 config/api_keys.php
+
+# Uploaded files
+public/uploads/
+
+# PHPUnit cache
+.phpunit.cache/

--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -330,6 +330,23 @@ if (!tableExists($pdo, 'job_notes')) {
     out('[OK] job_notes created');
 }
 
+// Ensure job_photos table
+if (!tableExists($pdo, 'job_photos')) {
+    out('[..] Creating table job_photos ...');
+    $pdo->exec(
+        "CREATE TABLE `job_photos` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `job_id` INT NOT NULL,
+            `technician_id` INT NOT NULL,
+            `path` VARCHAR(255) NOT NULL,
+            `label` VARCHAR(255) NOT NULL DEFAULT '',
+            `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] job_photos created');
+}
+
 // Drop deprecated job_jobtype table if present
 if (tableExists($pdo, 'job_jobtype')) {
     out('[..] Dropping table job_jobtype ...');
@@ -381,6 +398,9 @@ ensureFk($pdo, 'job_skill', 'skill_id', 'skills', 'id', 'fk_job_skill_skill', 'R
 
 ensureFk($pdo, 'job_notes', 'job_id', 'jobs', 'id', 'fk_job_notes_job', 'CASCADE', 'RESTRICT');
 ensureFk($pdo, 'job_notes', 'technician_id', 'employees', 'id', 'fk_job_notes_technician', 'RESTRICT', 'RESTRICT');
+
+ensureFk($pdo, 'job_photos', 'job_id', 'jobs', 'id', 'fk_job_photos_job', 'CASCADE', 'RESTRICT');
+ensureFk($pdo, 'job_photos', 'technician_id', 'employees', 'id', 'fk_job_photos_technician', 'RESTRICT', 'RESTRICT');
 
 
 ensureFk($pdo, 'job_employee_assignment', 'job_id', 'jobs', 'id', 'fk_jea_job', 'CASCADE', 'RESTRICT');

--- a/models/JobPhoto.php
+++ b/models/JobPhoto.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+/**
+ * JobPhoto model provides CRUD helpers for photos associated with jobs.
+ */
+final class JobPhoto
+{
+    /**
+     * List photos for a given job.
+     * @return list<array<string,mixed>>
+     */
+    public static function listForJob(PDO $pdo, int $jobId): array
+    {
+        $st = $pdo->prepare(
+            'SELECT id, job_id, technician_id, path, label, created_at
+             FROM job_photos
+             WHERE job_id = :jid
+             ORDER BY created_at DESC, id DESC'
+        );
+        if ($st === false) {
+            return [];
+        }
+        $st->execute([':jid' => $jobId]);
+        /** @var list<array<string,mixed>> $rows */
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(
+            static fn(array $r): array => [
+                'id' => (int)$r['id'],
+                'job_id' => (int)$r['job_id'],
+                'technician_id' => (int)$r['technician_id'],
+                'path' => (string)$r['path'],
+                'label' => (string)$r['label'],
+                'created_at' => (string)$r['created_at'],
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Insert new photo metadata. Returns inserted id.
+     */
+    public static function add(PDO $pdo, int $jobId, int $technicianId, string $path, string $label): int
+    {
+        $st = $pdo->prepare(
+            'INSERT INTO job_photos (job_id, technician_id, path, label) VALUES (:jid, :tid, :p, :l)'
+        );
+        $st->execute([':jid' => $jobId, ':tid' => $technicianId, ':p' => $path, ':l' => $label]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Fetch a photo by id.
+     * @return array<string,mixed>|null
+     */
+    public static function get(PDO $pdo, int $id): ?array
+    {
+        $st = $pdo->prepare(
+            'SELECT id, job_id, technician_id, path, label, created_at FROM job_photos WHERE id = :id'
+        );
+        if ($st === false) {
+            return null;
+        }
+        $st->execute([':id' => $id]);
+        /** @var array<string,mixed>|false $row */
+        $row = $st->fetch(PDO::FETCH_ASSOC);
+        return $row === false ? null : [
+            'id' => (int)$row['id'],
+            'job_id' => (int)$row['job_id'],
+            'technician_id' => (int)$row['technician_id'],
+            'path' => (string)$row['path'],
+            'label' => (string)$row['label'],
+            'created_at' => (string)$row['created_at'],
+        ];
+    }
+
+    /**
+     * Delete a photo by id. Returns true if a row was deleted.
+     */
+    public static function delete(PDO $pdo, int $id): bool
+    {
+        $st = $pdo->prepare('DELETE FROM job_photos WHERE id = :id');
+        $st->execute([':id' => $id]);
+        return $st->rowCount() > 0;
+    }
+}
+

--- a/public/api/get_job_details.php
+++ b/public/api/get_job_details.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 require_once __DIR__ . '/../../config/database.php';
 require_once __DIR__ . '/../../models/Job.php';
 require_once __DIR__ . '/../../models/JobNote.php';
+require_once __DIR__ . '/../../models/JobPhoto.php';
 
 header('Content-Type: application/json');
 
 $pdo = getPDO();
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
-$row   = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
-$notes = $id > 0 ? JobNote::listForJob($pdo, $id) : [];
+$row    = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
+$notes  = $id > 0 ? JobNote::listForJob($pdo, $id) : [];
+$photos = $id > 0 ? JobPhoto::listForJob($pdo, $id) : [];
 
-echo json_encode(['ok' => (bool)$row, 'job' => $row, 'notes' => $notes], JSON_UNESCAPED_SLASHES);
+echo json_encode(['ok' => (bool)$row, 'job' => $row, 'notes' => $notes, 'photos' => $photos], JSON_UNESCAPED_SLASHES);

--- a/public/api/job_photos_delete.php
+++ b/public/api/job_photos_delete.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require __DIR__ . '/../../models/JobPhoto.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    JsonResponse::json(['ok' => false, 'error' => 'Method not allowed', 'code' => 405], 405);
+    return;
+}
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$id = isset($data['id']) ? (int)$data['id'] : 0;
+if ($id <= 0) {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing id', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+try {
+    $pdo   = getPDO();
+    $photo = JobPhoto::get($pdo, $id);
+    if ($photo === null) {
+        JsonResponse::json(['ok' => false, 'error' => 'Not found', 'code' => 404], 404);
+        return;
+    }
+    $deleted = JobPhoto::delete($pdo, $id);
+    if ($deleted) {
+        $fullPath = __DIR__ . '/../' . $photo['path'];
+        if (is_file($fullPath)) {
+            @unlink($fullPath);
+        }
+    }
+    JsonResponse::json(['ok' => true, 'deleted' => $deleted]);
+} catch (Throwable $e) {
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}

--- a/public/api/job_photos_upload.php
+++ b/public/api/job_photos_upload.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require __DIR__ . '/../../models/JobPhoto.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    JsonResponse::json(['ok' => false, 'error' => 'Method not allowed', 'code' => 405], 405);
+    return;
+}
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$jobId        = isset($data['job_id']) ? (int)$data['job_id'] : 0;
+$technicianId = isset($data['technician_id']) ? (int)$data['technician_id'] : 0;
+$label        = trim((string)($data['label'] ?? ''));
+$file         = $_FILES['photo'] ?? null;
+
+if ($jobId <= 0 || $technicianId <= 0 || !is_array($file) || ($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing parameters', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+$ext = strtolower(pathinfo((string)$file['name'], PATHINFO_EXTENSION));
+$allowed = ['jpg','jpeg','png','gif'];
+if ($ext === '' || !in_array($ext, $allowed, true)) {
+    JsonResponse::json(['ok' => false, 'error' => 'Unsupported file type', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+$uploadDir = __DIR__ . '/../uploads/jobs/';
+if (!is_dir($uploadDir)) {
+    mkdir($uploadDir, 0777, true);
+}
+$filename     = 'job_' . $jobId . '_' . time() . '_' . bin2hex(random_bytes(4)) . '.' . $ext;
+$destPath     = $uploadDir . $filename;
+$relativePath = 'uploads/jobs/' . $filename;
+
+if (!move_uploaded_file((string)$file['tmp_name'], $destPath)) {
+    JsonResponse::json(['ok' => false, 'error' => 'Upload failed', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $id  = JobPhoto::add($pdo, $jobId, $technicianId, $relativePath, $label);
+    JsonResponse::json(['ok' => true, 'id' => $id, 'path' => $relativePath]);
+} catch (Throwable $e) {
+    @unlink($destPath);
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}

--- a/tests/migrations/20241004130000_create_job_photos.sql
+++ b/tests/migrations/20241004130000_create_job_photos.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS job_photos (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    job_id INT NOT NULL,
+    technician_id INT NOT NULL,
+    path VARCHAR(255) NOT NULL,
+    label VARCHAR(255) NOT NULL DEFAULT '',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_job_photos_job_id (job_id),
+    CONSTRAINT fk_job_photos_job FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,
+    CONSTRAINT fk_job_photos_technician FOREIGN KEY (technician_id) REFERENCES employees(id) ON DELETE RESTRICT
+);


### PR DESCRIPTION
## Summary
- create `job_photos` table with FK links to jobs and employees
- add `JobPhoto` model for listing, adding, and deleting photos
- support photo upload and deletion APIs and expose metadata in job detail API

## Testing
- `make test` *(fails: DB connection refused during integration tests)*
- `make lint` *(fails: Found 168 errors)*


------
https://chatgpt.com/codex/tasks/task_e_68a3c5627944832fbf751e75acbfea58