### PR TITLE
Add job checklist items with API endpoints and seeding

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -359,6 +359,22 @@ if (!tableExists($pdo, 'job_photos')) {
     out('[OK] job_photos created');
 }
 
+// Ensure job_checklist_items table
+if (!tableExists($pdo, 'job_checklist_items')) {
+    out('[..] Creating table job_checklist_items ...');
+    $pdo->exec(
+        "CREATE TABLE `job_checklist_items` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+            `job_id` INT NOT NULL,
+            `description` VARCHAR(255) NOT NULL,
+            `is_completed` TINYINT(1) NOT NULL DEFAULT 0,
+            `completed_at` DATETIME NULL,
+            PRIMARY KEY (`id`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] job_checklist_items created');
+}
+
 // Drop deprecated job_jobtype table if present
 if (tableExists($pdo, 'job_jobtype')) {
     out('[..] Dropping table job_jobtype ...');
@@ -388,7 +404,7 @@ if (tableExists($pdo, 'employee_availability_overrides')) {
 }
 
 out("== Ensuring PRIMARY KEYS ==");
-foreach (['people','employees','job_types','employee_availability_overrides','availability_audit'] as $t) {
+foreach (['people','employees','job_types','employee_availability_overrides','availability_audit','job_checklist_items'] as $t) {
     ensureAutoPk($pdo, $t);
 }
 
@@ -413,6 +429,8 @@ ensureFk($pdo, 'job_notes', 'technician_id', 'employees', 'id', 'fk_job_notes_te
 
 ensureFk($pdo, 'job_photos', 'job_id', 'jobs', 'id', 'fk_job_photos_job', 'CASCADE', 'RESTRICT');
 ensureFk($pdo, 'job_photos', 'technician_id', 'employees', 'id', 'fk_job_photos_technician', 'RESTRICT', 'RESTRICT');
+
+ensureFk($pdo, 'job_checklist_items', 'job_id', 'jobs', 'id', 'fk_job_checklist_job', 'CASCADE', 'RESTRICT');
 
 
 ensureFk($pdo, 'job_employee_assignment', 'job_id', 'jobs', 'id', 'fk_jea_job', 'CASCADE', 'RESTRICT');

--- a/bin/schema_check.php
+++ b/bin/schema_check.php
@@ -133,6 +133,7 @@ $required = [
   'jobtype_skills' => ['job_type_id','skill_id'],
   'employee_availability' => ['id','employee_id','day_of_week','start_time','end_time'],
   'job_employee_assignment' => ['id','job_id','employee_id','assigned_at'],
+  'job_checklist_items' => ['id','job_id','description','is_completed','completed_at'],
 ];
 
 foreach ($required as $t => $colsNeed) {
@@ -144,7 +145,7 @@ foreach ($required as $t => $colsNeed) {
 }
 
 // AUTO_INCREMENT PKs
-foreach (['people','employees','customers','jobs','job_types','skills','employee_availability','job_employee_assignment'] as $t) {
+foreach (['people','employees','customers','jobs','job_types','skills','employee_availability','job_employee_assignment','job_checklist_items'] as $t) {
     if (!tableExists($pdo, $t)) continue;
     if (!hasAutoPk(columns($pdo, $t), 'id')) {
         $issues[] = "Primary key AUTO_INCREMENT missing or not primary on $t.id";
@@ -166,6 +167,9 @@ $fkExpect = [
   'job_employee_assignment' => [
       ['cols'=>['job_id'],'ref'=>'jobs','refcols'=>['id']],
       ['cols'=>['employee_id'],'ref'=>'employees','refcols'=>['id']],
+  ],
+  'job_checklist_items' => [
+      ['cols'=>['job_id'],'ref'=>'jobs','refcols'=>['id']],
   ],
 ];
 foreach ($fkExpect as $t=>$list) {

--- a/models/JobChecklistItem.php
+++ b/models/JobChecklistItem.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+/**
+ * Helper methods for checklist items associated with jobs.
+ */
+final class JobChecklistItem
+{
+    /**
+     * Default checklist templates keyed by job type id.
+     * @var array<int, list<string>>
+     */
+    private const DEFAULT_TEMPLATES = [
+        // Basic installation job
+        1 => [
+            'Review work order',
+            'Confirm materials on site',
+            'Perform installation',
+            'Test and verify operation',
+        ],
+        // Routine maintenance job
+        2 => [
+            'Inspect equipment condition',
+            'Perform routine maintenance',
+            'Update service log',
+        ],
+    ];
+
+    /**
+     * Fetch checklist items for a job.
+     * @return list<array{id:int,job_id:int,description:string,is_completed:bool,completed_at:?string}>
+     */
+    public static function listForJob(PDO $pdo, int $jobId): array
+    {
+        $st = $pdo->prepare(
+            'SELECT id, job_id, description, is_completed, completed_at
+             FROM job_checklist_items
+             WHERE job_id = :jid
+             ORDER BY id'
+        );
+        if ($st === false) {
+            return [];
+        }
+        $st->execute([':jid' => $jobId]);
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(
+            static fn(array $r): array => [
+                'id' => (int)$r['id'],
+                'job_id' => (int)$r['job_id'],
+                'description' => (string)$r['description'],
+                'is_completed' => (bool)$r['is_completed'],
+                'completed_at' => $r['completed_at'] !== null ? (string)$r['completed_at'] : null,
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Toggle completion state of an item. Returns new state or null if not found.
+     */
+    public static function toggle(PDO $pdo, int $id): ?bool
+    {
+        $st = $pdo->prepare('SELECT is_completed FROM job_checklist_items WHERE id = :id');
+        if ($st === false) {
+            return null;
+        }
+        $st->execute([':id' => $id]);
+        $cur = $st->fetchColumn();
+        if ($cur === false) {
+            return null;
+        }
+        $new = ((int)$cur) === 1 ? 0 : 1;
+        $upd = $pdo->prepare('UPDATE job_checklist_items SET is_completed = :c, completed_at = :ts WHERE id = :id');
+        $upd->execute([
+            ':c' => $new,
+            ':ts' => $new === 1 ? date('Y-m-d H:i:s') : null,
+            ':id' => $id,
+        ]);
+        if ($upd->rowCount() === 0) {
+            return null;
+        }
+        return $new === 1;
+    }
+
+    /**
+     * Seed default checklist rows for a job based on job type id.
+     * @param int $jobTypeId The job type identifier.
+     */
+    public static function seedDefaults(PDO $pdo, int $jobId, int $jobTypeId): void
+    {
+        $templates = self::DEFAULT_TEMPLATES[$jobTypeId] ?? [];
+        if ($templates === []) {
+            return;
+        }
+        $st = $pdo->prepare('INSERT INTO job_checklist_items (job_id, description) VALUES (:jid, :desc)');
+        foreach ($templates as $desc) {
+            $st->execute([':jid' => $jobId, ':desc' => $desc]);
+        }
+    }
+}

--- a/public/api/job_checklist.php
+++ b/public/api/job_checklist.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require __DIR__ . '/../../models/JobChecklistItem.php';
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
+if ($jobId <= 0) {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing job_id', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $items = JobChecklistItem::listForJob($pdo, $jobId);
+    JsonResponse::json(['ok' => true, 'items' => $items]);
+} catch (Throwable $e) {
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}

--- a/public/api/job_checklist_update.php
+++ b/public/api/job_checklist_update.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require __DIR__ . '/../../models/JobChecklistItem.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    JsonResponse::json(['ok' => false, 'error' => 'Method not allowed', 'code' => 405], 405);
+    return;
+}
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$id = isset($data['id']) ? (int)$data['id'] : 0;
+if ($id <= 0) {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing id', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $newState = JobChecklistItem::toggle($pdo, $id);
+    if ($newState === null) {
+        JsonResponse::json(['ok' => false, 'error' => 'Not found', 'code' => \ErrorCodes::NOT_FOUND], 404);
+        return;
+    }
+    JsonResponse::json(['ok' => true, 'is_completed' => $newState]);
+} catch (Throwable $e) {
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/_csrf.php';
 require_once __DIR__ . '/../models/Skill.php';
 require_once __DIR__ . '/../models/Job.php';
 require_once __DIR__ . '/../models/Customer.php';
+require_once __DIR__ . '/../models/JobChecklistItem.php';
 
 $pdo = getPDO();
 $__csrf = csrf_token();
@@ -19,6 +20,7 @@ $isEdit      = $mode === 'edit';
 $skills    = Skill::all($pdo);
 $statuses  = $isEdit ? Job::allowedStatuses() : array_intersect(['scheduled','draft'], Job::allowedStatuses());
 $customers = (new Customer($pdo))->getAll();
+$jobTypes  = $pdo->query('SELECT id, name FROM job_types ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 $today     = date('Y-m-d');
 
 /** HTML escape */
@@ -94,6 +96,17 @@ function stickyArr(string $name, array $default = []): array {
             <?php endforeach; ?>
           </select>
           <div class="invalid-feedback d-block" id="jobSkillError" style="display:none">Select at least one skill.</div>
+        </div>
+        <div class="mb-3">
+          <label for="job_type_id" class="form-label">Job Type</label>
+          <?php $selJobType = sticky('job_type_id', ''); ?>
+          <select name="job_type_id" id="job_type_id" class="form-select">
+            <option value="">-- Select --</option>
+            <?php foreach ($jobTypes as $jt): ?>
+              <?php $jtId = (string)$jt['id']; ?>
+              <option value="<?= s($jtId) ?>" <?= $selJobType === $jtId ? 'selected' : '' ?>><?= s($jt['name']) ?></option>
+            <?php endforeach; ?>
+          </select>
         </div>
         <div class="mb-3">
           <label for="status" class="form-label">Status <span class="text-danger">*</span></label>

--- a/public/job_save.php
+++ b/public/job_save.php
@@ -54,6 +54,7 @@ $statusIn        = trim((string)($_POST['status'] ?? ''));
 $skillIds        = isset($_POST['skills']) && is_array($_POST['skills'])
     ? array_values(array_filter(array_map('intval', $_POST['skills']), static fn($v) => $v > 0))
     : [];
+$jobTypeId      = isset($_POST['job_type_id']) ? (int)$_POST['job_type_id'] : 0;
 
 // Normalize status to canonical ENUM values (lowercase)
 $map = [
@@ -98,6 +99,7 @@ if ($errors) {
 }
 
 require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../models/JobChecklistItem.php';
 
 try {
   $pdo = getPDO();
@@ -140,6 +142,10 @@ try {
       foreach ($skillIds as $sid) {
           $ins->execute([':jid' => $jobId, ':sid' => $sid]);
       }
+  }
+
+  if ($id <= 0 && $jobTypeId > 0) {
+      JobChecklistItem::seedDefaults($pdo, $jobId, $jobTypeId);
   }
 
   $pdo->commit();


### PR DESCRIPTION
## Summary
- add `job_checklist_items` table with schema and FK
- implement `JobChecklistItem` model with helpers and seed templates
- expose API endpoints to list and toggle checklist items
- seed default checklist items when creating a job and allow selecting job type

## Testing
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ca2613a4832fbbac2b3f7b329ee2