### PR TITLE
Lock window editing to single day

### DIFF
--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -295,12 +295,17 @@ function openAdd() {
   winId.value = '';
   winEmployee.value = `${currentEmployeeName()} (ID ${currentEmployeeId()})`;
   winDays.value = 'Monday';
+  winDays.disabled = false;
   winReplaceIds.value = '';
   clearBlocks();
   addBlock('09:00', '17:00');
   winRecurring.checked = true;
   winStartDate.value = currentWeekStart();
   winEndDate.value = '';
+  btnWeekdays.classList.remove('d-none');
+  btnWeekdays.disabled = false;
+  btnClearWeek.classList.remove('d-none');
+  btnClearWeek.disabled = false;
   toggleRecurring();
   winModal.show();
 }
@@ -310,6 +315,7 @@ function openEditDay(day) {
   winId.value = '';
   winEmployee.value = `${currentEmployeeName()} (ID ${currentEmployeeId()})`;
   winDays.value = day;
+  winDays.disabled = true;
   const arr = currentGroups[day] || [];
   winReplaceIds.value = arr.map(it => it.id).join(',');
   clearBlocks();
@@ -322,6 +328,10 @@ function openEditDay(day) {
   let sd = arr[0] && arr[0].start_date ? arr[0].start_date : currentWeekStart();
   winStartDate.value = sd;
   winEndDate.value = '';
+  btnWeekdays.classList.add('d-none');
+  btnWeekdays.disabled = true;
+  btnClearWeek.classList.add('d-none');
+  btnClearWeek.disabled = true;
   toggleRecurring();
   winModal.show();
 }


### PR DESCRIPTION
## Summary
- Restrict availability window editing to the selected day by disabling the day selector
- Hide copy helper buttons when editing and re-enable them for new entries

## Testing
- `make lint` (fails: Found 197 errors)
- `make test` (fails: DB connection refused in integration tests)


------
https://chatgpt.com/codex/tasks/task_e_68a3cb2bbf84832fa2ed9312b1737418