### PR TITLE
Add week start handling for availability onboarding wizard

### DIFF
--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -38,6 +38,9 @@ function dow_is_int(PDO $pdo): bool {
 }
 
 $__csrf = csrf_token();
+$weekStart = isset($_GET['week_start']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', (string)$_GET['week_start'])
+    ? (string)$_GET['week_start']
+    : date('Y-m-d', strtotime('monday this week'));
 
 // JSON list endpoint for AJAX reloads
 if (($_GET['action'] ?? '') === 'list') {
@@ -133,7 +136,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
         <div id="weekDisplay" class="text-muted small"></div>
       </div>
       <a href="availability_form.php" class="btn btn-outline-secondary btn-sm">Classic Form</a>
-      <a href="availability_onboard.php?employee_id=<?= $selectedEmployeeId ?: '' ?>" class="btn btn-outline-primary btn-sm ms-2">Setup Wizard</a>
+      <a href="availability_onboard.php?employee_id=<?= $selectedEmployeeId ?: '' ?>&week_start=<?= s($weekStart) ?>" class="btn btn-outline-primary btn-sm ms-2">Setup Wizard</a>
     </div>
 
     <div id="alertBox" class="alert d-none" role="alert"></div>
@@ -152,7 +155,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
           </div>
           <div class="col-sm-5 col-md-4 col-lg-3">
             <label class="form-label">Week of</label>
-            <input type="date" id="weekStart" class="form-control">
+            <input type="date" id="weekStart" class="form-control" value="<?= s($weekStart) ?>">
           </div>
           <div class="col-auto">
             <a href="#" class="btn btn-outline-primary disabled" id="btnProfile" aria-label="View selected employee profile" aria-disabled="true">View Profile</a>

--- a/public/availability_onboard.php
+++ b/public/availability_onboard.php
@@ -7,7 +7,9 @@ require_once __DIR__ . '/_csrf.php';
 function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
 
 $employeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 0;
-$weekStart  = date('Y-m-d', strtotime('monday this week'));
+$weekStart  = isset($_GET['week_start']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', (string)$_GET['week_start'])
+    ? (string)$_GET['week_start']
+    : date('Y-m-d', strtotime('monday this week'));
 $__csrf     = csrf_token();
 ?>
 <!doctype html>
@@ -51,6 +53,7 @@ $__csrf     = csrf_token();
     const dayTitle = document.getElementById('dayTitle');
     const startInput = document.getElementById('startTime');
     const endInput = document.getElementById('endTime');
+    const weekInput = document.getElementById('weekStart');
     const nextBtn = document.getElementById('nextBtn');
 
     function showDay(){
@@ -77,7 +80,8 @@ $__csrf     = csrf_token();
         if(idx < days.length){
           showDay();
         } else {
-          window.location.href = 'availability_manager.php?employee_id=' + encodeURIComponent(empId);
+          const qs = 'employee_id=' + encodeURIComponent(empId) + '&week_start=' + encodeURIComponent(weekInput.value);
+          window.location.href = 'availability_manager.php?' + qs;
         }
       }).catch(()=>alert('Request failed'));
     }

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -69,7 +69,13 @@
           showToast(mode === 'edit' ? 'Employee updated' : 'Employee saved');
           setTimeout(function(){
             var dest = 'employees.php';
-            if (mode === 'add' && data && data.id) { dest = 'availability_onboard.php?employee_id=' + encodeURIComponent(data.id); }
+            if (mode === 'add' && data && data.id) {
+              var today = new Date();
+              var diff = today.getDay() === 0 ? -6 : 1 - today.getDay();
+              today.setDate(today.getDate() + diff);
+              var weekStart = today.toISOString().slice(0,10);
+              dest = 'availability_onboard.php?employee_id=' + encodeURIComponent(data.id) + '&week_start=' + weekStart;
+            }
             window.location.href = dest;
           },800);
           return;


### PR DESCRIPTION
## Summary
- Allow availability onboarding wizard to accept a `week_start` parameter and pass it to Availability Manager
- Pre-fill Availability Manager's week picker and wizard link with selected week
- Redirect new employee saves to onboarding wizard with week start

## Testing
- `make lint` *(fails: Found 226 errors)*
- `make test` *(fails: PDOException: DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cc9069ac832f818dea11d3aba560