### PR TITLE
Add job completion artifacts and validation

### DIFF
--- a/models/Job.php
+++ b/models/Job.php
@@ -112,6 +112,19 @@ final class Job
      */
     public static function complete(PDO $pdo, int $jobId, ?float $lat, ?float $lng): bool
     {
+        $noteSt  = $pdo->prepare('SELECT COUNT(*) FROM job_notes WHERE job_id = :id AND is_final = 1');
+        $photoSt = $pdo->prepare('SELECT COUNT(*) FROM job_photos WHERE job_id = :id');
+        $sigSt   = $pdo->prepare('SELECT COUNT(*) FROM job_completion WHERE job_id = :id AND signature_path <> ""');
+        if ($noteSt === false || $photoSt === false || $sigSt === false) {
+            return false;
+        }
+        $noteSt->execute([':id' => $jobId]);
+        $photoSt->execute([':id' => $jobId]);
+        $sigSt->execute([':id' => $jobId]);
+        if ((int)$noteSt->fetchColumn() <= 0 || (int)$photoSt->fetchColumn() <= 0 || (int)$sigSt->fetchColumn() <= 0) {
+            return false;
+        }
+
         $st = $pdo->prepare(
             'UPDATE jobs
              SET status = "completed", completed_at = NOW(), location_lat = :lat, location_lng = :lng, updated_at = NOW()

--- a/models/JobCompletion.php
+++ b/models/JobCompletion.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+final class JobCompletion
+{
+    /**
+     * Save signature path for a job.
+     */
+    public static function save(PDO $pdo, int $jobId, string $signaturePath): bool
+    {
+        $st = $pdo->prepare(
+            'INSERT INTO job_completion (job_id, signature_path) VALUES (:jid, :sp)
+             ON DUPLICATE KEY UPDATE signature_path = VALUES(signature_path)'
+        );
+        if ($st === false) {
+            return false;
+        }
+        $st->execute([':jid' => $jobId, ':sp' => $signaturePath]);
+        return $st->rowCount() > 0;
+    }
+}

--- a/models/JobNote.php
+++ b/models/JobNote.php
@@ -12,7 +12,7 @@ final class JobNote
     public static function listForJob(PDO $pdo, int $jobId): array
     {
         $st = $pdo->prepare(
-            'SELECT id, job_id, technician_id, note, created_at
+            'SELECT id, job_id, technician_id, note, is_final, created_at
              FROM job_notes
              WHERE job_id = :jid
              ORDER BY created_at DESC, id DESC'
@@ -29,6 +29,7 @@ final class JobNote
                 'job_id' => (int)$r['job_id'],
                 'technician_id' => (int)$r['technician_id'],
                 'note' => (string)$r['note'],
+                'is_final' => (bool)$r['is_final'],
                 'created_at' => (string)$r['created_at'],
             ],
             $rows
@@ -38,12 +39,12 @@ final class JobNote
     /**
      * Add a new note for a job. Returns inserted id.
      */
-    public static function add(PDO $pdo, int $jobId, int $technicianId, string $note): int
+    public static function add(PDO $pdo, int $jobId, int $technicianId, string $note, bool $final = false): int
     {
         $st = $pdo->prepare(
-            'INSERT INTO job_notes (job_id, technician_id, note) VALUES (:jid, :tid, :n)'
+            'INSERT INTO job_notes (job_id, technician_id, note, is_final) VALUES (:jid, :tid, :n, :f)'
         );
-        $st->execute([':jid' => $jobId, ':tid' => $technicianId, ':n' => $note]);
+        $st->execute([':jid' => $jobId, ':tid' => $technicianId, ':n' => $note, ':f' => $final ? 1 : 0]);
         return (int)$pdo->lastInsertId();
     }
 

--- a/tests/Integration/JobCompleteTest.php
+++ b/tests/Integration/JobCompleteTest.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+require_once __DIR__ . '/../support/TestDataFactory.php';
+
+final class JobCompleteTest extends TestCase
+{
+    private PDO $pdo;
+    private int $jobId;
+    private int $techId;
+
+    protected function setUp(): void
+    {
+        require_once __DIR__ . '/../../config/database.php';
+        $this->pdo = getPDO();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec('DELETE FROM job_completion');
+        $this->pdo->exec('DELETE FROM job_photos');
+        $this->pdo->exec('DELETE FROM job_notes');
+        $this->pdo->exec('DELETE FROM jobs');
+        $this->pdo->exec('DELETE FROM employees');
+        $this->pdo->exec('DELETE FROM people');
+        $this->pdo->exec('DELETE FROM customers');
+
+        $customerId   = TestDataFactory::createCustomer($this->pdo);
+        $this->techId = TestDataFactory::createEmployee($this->pdo);
+        $this->jobId  = TestDataFactory::createJob($this->pdo, $customerId, 'Test job', '2025-01-01', '09:00:00', 60, 'in_progress');
+    }
+
+    private function sampleImage(): string
+    {
+        return 'data:image/png;base64,' .
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAgMBAJRfB9kAAAAASUVORK5CYII=';
+    }
+
+    public function testCompletionSavesArtifactsAndUpdatesStatus(): void
+    {
+        $img = $this->sampleImage();
+        $res = EndpointHarness::run(__DIR__ . '/../../public/api/job_complete.php', [
+            'job_id'        => $this->jobId,
+            'technician_id'=> $this->techId,
+            'location_lat' => '1',
+            'location_lng' => '2',
+            'final_note'   => 'All done',
+            'final_photos' => [$img],
+            'signature'    => $img,
+        ], ['role' => 'technician']);
+
+        $this->assertTrue($res['ok'] ?? false);
+        $status = $this->pdo->query('SELECT status FROM jobs WHERE id=' . $this->jobId)->fetchColumn();
+        $this->assertSame('completed', $status);
+        $noteCount = (int)$this->pdo->query('SELECT COUNT(*) FROM job_notes WHERE job_id=' . $this->jobId . ' AND is_final=1')->fetchColumn();
+        $this->assertSame(1, $noteCount);
+        $photoCount = (int)$this->pdo->query('SELECT COUNT(*) FROM job_photos WHERE job_id=' . $this->jobId)->fetchColumn();
+        $this->assertSame(1, $photoCount);
+        $sigPath = $this->pdo->query('SELECT signature_path FROM job_completion WHERE job_id=' . $this->jobId)->fetchColumn();
+        $this->assertIsString($sigPath);
+        $this->assertNotSame('', $sigPath);
+    }
+
+    public function testCompletionRequiresNoteAndPhoto(): void
+    {
+        $img = $this->sampleImage();
+
+        $noNote = EndpointHarness::run(__DIR__ . '/../../public/api/job_complete.php', [
+            'job_id'        => $this->jobId,
+            'technician_id'=> $this->techId,
+            'location_lat' => '1',
+            'location_lng' => '2',
+            'final_note'   => '',
+            'final_photos' => [$img],
+            'signature'    => $img,
+        ], ['role' => 'technician']);
+        $this->assertFalse($noNote['ok'] ?? true);
+        $this->assertSame(422, $noNote['code'] ?? 0);
+
+        $noPhoto = EndpointHarness::run(__DIR__ . '/../../public/api/job_complete.php', [
+            'job_id'        => $this->jobId,
+            'technician_id'=> $this->techId,
+            'location_lat' => '1',
+            'location_lng' => '2',
+            'final_note'   => 'done',
+            'final_photos' => [],
+            'signature'    => $img,
+        ], ['role' => 'technician']);
+        $this->assertFalse($noPhoto['ok'] ?? true);
+        $this->assertSame(422, $noPhoto['code'] ?? 0);
+    }
+}

--- a/tests/migrations/20241004120000_create_job_notes.sql
+++ b/tests/migrations/20241004120000_create_job_notes.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS job_notes (
     job_id INT NOT NULL,
     technician_id INT NOT NULL,
     note TEXT NOT NULL,
+    is_final TINYINT(1) NOT NULL DEFAULT 0,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_job_notes_job_id (job_id),
     CONSTRAINT fk_job_notes_job FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,

--- a/tests/migrations/20241004140000_create_job_completion.sql
+++ b/tests/migrations/20241004140000_create_job_completion.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS job_completion (
+    job_id INT NOT NULL PRIMARY KEY,
+    signature_path VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_job_completion_job FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- Extend job completion API to capture final notes, photos, and signature
- Track final notes and signature in new database structures
- Ensure jobs only complete after required artifacts and validation

## Testing
- `vendor/bin/phpunit tests/Integration/JobCompleteTest.php` (fails: DB connection failed)

------
https://chatgpt.com/codex/tasks/task_e_68a3ccb88f5c832fb9c29d254dba116a