### PR TITLE
Add PTO quick button and default override reason

### DIFF
--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -161,6 +161,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
             <a href="#" class="btn btn-outline-primary disabled" id="btnProfile" aria-label="View selected employee profile" aria-disabled="true">View Profile</a>
             <button type="button" class="btn btn-success ms-2" id="btnAdd">Add Window</button>
             <button type="button" class="btn btn-warning ms-2" id="btnAddOverride">Add Override</button>
+            <button type="button" class="btn btn-outline-warning ms-2" id="btnQuickPTO">PTO</button>
             <button type="button" class="btn btn-outline-info ms-2" id="btnExport">Export</button>
             <button type="button" class="btn btn-outline-secondary ms-2" id="btnPrint">Print</button>
 
@@ -323,11 +324,11 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
               <?php endforeach; ?>
             </select>
           </div>
-          <div class="col-6">
+          <div class="col-6 ov-time">
             <label class="form-label">Start</label>
             <input type="time" class="form-control" id="ov_start_time">
           </div>
-          <div class="col-6">
+          <div class="col-6 ov-time">
             <label class="form-label">End</label>
             <input type="time" class="form-control" id="ov_end_time">
           </div>

--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -15,6 +15,7 @@ const resultSelect = document.getElementById('employeeResults');
 const btnProfile = document.getElementById('btnProfile');
 const btnAdd = document.getElementById('btnAdd');
 const btnAddOverride = document.getElementById('btnAddOverride');
+const btnQuickPTO = document.getElementById('btnQuickPTO');
 
 const weekStartInput = document.getElementById('weekStart');
 const weekDisplay = document.getElementById('weekDisplay');
@@ -546,6 +547,7 @@ ovForm.addEventListener('submit', async (e) => {
 
 document.getElementById('btnAdd').addEventListener('click', openAdd);
 btnAddOverride.addEventListener('click', () => openOvAdd(currentWeekStart()));
+btnQuickPTO?.addEventListener('click', () => openOvAdd(currentWeekStart(), { status: 'UNAVAILABLE', type: 'PTO', reason: 'Vacation' }));
 
 btnExport.addEventListener('click', () => {
   const eid = currentEmployeeId();

--- a/public/js/override-handlers.js
+++ b/public/js/override-handlers.js
@@ -13,7 +13,18 @@ const ovStatus = document.getElementById('ov_status');
 const ovType = document.getElementById('ov_type');
 const ovReason = document.getElementById('ov_reason');
 
-export function openOvAdd(weekStart) {
+function updateOvTimeFields() {
+  const show = ovStatus.value === 'PARTIAL';
+  ovStartTime.closest('.ov-time').classList.toggle('d-none', !show);
+  ovEndTime.closest('.ov-time').classList.toggle('d-none', !show);
+  if (!show) {
+    ovStartTime.value = '';
+    ovEndTime.value = '';
+  }
+}
+ovStatus.addEventListener('change', updateOvTimeFields);
+
+export function openOvAdd(weekStart, opts = {}) {
   ovTitle.textContent = 'Add Override';
   ovId.value = '';
   ovStartDate.value = weekStart;
@@ -21,9 +32,10 @@ export function openOvAdd(weekStart) {
   Array.from(ovDays.options).forEach(o => { o.selected = false; });
   ovStartTime.value = '';
   ovEndTime.value = '';
-  ovStatus.value = 'UNAVAILABLE';
-  ovType.value = 'PTO';
-  ovReason.value = '';
+  ovStatus.value = opts.status ?? 'UNAVAILABLE';
+  ovType.value = opts.type ?? 'PTO';
+  ovReason.value = opts.reason ?? '';
+  updateOvTimeFields();
   ovModal.show();
 }
 
@@ -38,6 +50,7 @@ export function openOvEdit(ov) {
   ovStatus.value = ov.status || 'UNAVAILABLE';
   ovType.value = ov.type || 'PTO';
   ovReason.value = ov.reason || '';
+  updateOvTimeFields();
   ovModal.show();
 }
 


### PR DESCRIPTION
## Summary
- Add PTO quick button to Availability Manager to prefill override modal
- Hide override time fields unless status is partial
- Populate default "Vacation" reason for quick PTO entries

## Testing
- `make all` *(fails: 226 phpstan errors)*
- `make test` *(fails: DB connection refused during integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cd9e859c832fa230079ec56c92df