### PR TITLE
Add technician job pages with API integrations

### DIFF
--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -1,0 +1,132 @@
+// /public/js/tech_job.js
+(() => {
+  function ready(fn){document.readyState!=='loading'?fn():document.addEventListener('DOMContentLoaded',fn);}
+  function h(s){const d=document.createElement('div');d.textContent=s==null?'':String(s);return d.innerHTML;}
+  const csrf=window.CSRF_TOKEN;
+  const jobId=Number(window.JOB_ID);
+  const techId=Number(window.TECH_ID);
+  ready(() => {
+    const details=document.getElementById('job-details');
+    const btnStart=document.getElementById('btn-start-job');
+    const btnNote=document.getElementById('btn-add-note');
+    const btnPhoto=document.getElementById('btn-add-photo');
+    const btnChecklist=document.getElementById('btn-checklist');
+    const btnComplete=document.getElementById('btn-complete');
+    const fileInput=document.createElement('input');
+    fileInput.type='file';
+    fileInput.accept='image/*';
+    fileInput.style.display='none';
+    document.body.appendChild(fileInput);
+
+    fetch(`/api/get_job_details.php?id=${jobId}`,{credentials:'same-origin'})
+      .then(r=>r.json())
+      .then(data=>{
+        if(!data?.ok) throw new Error('Job not found');
+        const j=data.job;
+        details.innerHTML=`<h1 class="h5">${h(j.description||'')}</h1>
+<div>${h(j.customer.first_name||'')} ${h(j.customer.last_name||'')}</div>
+<div class="text-muted">${h(j.customer.address_line1||'')}</div>`;
+        if(j.status==='scheduled'){btnStart.classList.remove('d-none');}
+      })
+      .catch(err=>{details.innerHTML=`<div class="text-danger">${h(err.message)}</div>`;});
+
+    btnStart?.addEventListener('click',()=>{
+      btnStart.disabled=true;
+      navigator.geolocation.getCurrentPosition(pos=>{
+        const fd=new FormData();
+        fd.append('job_id',jobId);
+        fd.append('location_lat',pos.coords.latitude);
+        fd.append('location_lng',pos.coords.longitude);
+        fd.append('csrf_token',csrf);
+        fetch('/api/job_start.php',{method:'POST',body:fd,credentials:'same-origin'})
+          .then(r=>r.json())
+          .then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');btnStart.classList.add('d-none');})
+          .catch(err=>{alert(err.message||'Failed');btnStart.disabled=false;});
+      },()=>{alert('Location required');btnStart.disabled=false;});
+    });
+
+    btnNote?.addEventListener('click',()=>{
+      const note=prompt('Enter note:');
+      if(!note) return;
+      const fd=new FormData();
+      fd.append('job_id',jobId);
+      fd.append('technician_id',techId);
+      fd.append('note',note);
+      fd.append('csrf_token',csrf);
+      fetch('/api/job_notes_add.php',{method:'POST',body:fd,credentials:'same-origin'})
+        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');alert('Note added');})
+        .catch(err=>alert(err.message||'Failed'));
+    });
+
+    btnPhoto?.addEventListener('click',()=>fileInput.click());
+    fileInput.addEventListener('change',()=>{
+      if(!fileInput.files[0]) return;
+      const fd=new FormData();
+      fd.append('job_id',jobId);
+      fd.append('technician_id',techId);
+      fd.append('photo',fileInput.files[0]);
+      fd.append('csrf_token',csrf);
+      fetch('/api/job_photos_upload.php',{method:'POST',body:fd,credentials:'same-origin'})
+        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');alert('Photo uploaded');fileInput.value='';})
+        .catch(err=>{alert(err.message||'Upload failed');fileInput.value='';});
+    });
+
+    btnChecklist?.addEventListener('click',async()=>{
+      try{
+        const res=await fetch(`/api/job_checklist.php?job_id=${jobId}`,{credentials:'same-origin'});
+        const data=await res.json();
+        if(!Array.isArray(data?.items)) throw new Error('No checklist');
+        const checked=await showChecklistModal(data.items);
+        if(!checked) return;
+        const fd=new FormData();
+        fd.append('job_id',jobId);
+        fd.append('items',JSON.stringify(checked));
+        fd.append('csrf_token',csrf);
+        const res2=await fetch('/api/job_checklist_update.php',{method:'POST',body:fd,credentials:'same-origin'});
+        const data2=await res2.json();
+        if(!data2?.ok) throw new Error(data2?.error||'Failed');
+        alert('Checklist saved');
+      }catch(err){alert(err.message||'Checklist failed');}
+    });
+
+    async function showChecklistModal(items){
+      return new Promise(resolve=>{
+        const modal=document.createElement('div');
+        modal.className='modal fade';
+        modal.innerHTML=`<div class="modal-dialog"><div class="modal-content">
+<div class="modal-header"><h5 class="modal-title">Checklist</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+<div class="modal-body"></div>
+<div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button><button type="button" class="btn btn-primary" id="chk-save">Save</button></div>
+</div></div>`;
+        const body=modal.querySelector('.modal-body');
+        items.forEach((it,i)=>{
+          const id='chk'+i;
+          const div=document.createElement('div');
+          div.className='form-check';
+          div.innerHTML=`<input class="form-check-input" type="checkbox" id="${id}" ${it.completed?'checked':''}>
+<label class="form-check-label" for="${id}">${h(it.item||it.description||'')}</label>`;
+          body.appendChild(div);
+        });
+        document.body.appendChild(modal);
+        const bsModal=new bootstrap.Modal(modal);
+        modal.addEventListener('hidden.bs.modal',()=>{modal.remove();resolve(null);});
+        modal.querySelector('#chk-save').addEventListener('click',()=>{
+          const res=[];
+          body.querySelectorAll('input[type="checkbox"]').forEach((cb,idx)=>{res.push({id:items[idx].id,completed:cb.checked});});
+          bsModal.hide();resolve(res);
+        });
+        bsModal.show();
+      });
+    }
+
+    btnComplete?.addEventListener('click',()=>{
+      if(!confirm('Mark job complete?')) return;
+      const fd=new FormData();
+      fd.append('job_id',jobId);
+      fd.append('csrf_token',csrf);
+      fetch('/api/job_complete.php',{method:'POST',body:fd,credentials:'same-origin'})
+        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');alert('Job completed');})
+        .catch(err=>alert(err.message||'Failed'));
+    });
+  });
+})();

--- a/public/js/tech_jobs.js
+++ b/public/js/tech_jobs.js
@@ -1,0 +1,34 @@
+// /public/js/tech_jobs.js
+(() => {
+  function ready(fn){document.readyState!=='loading'?fn():document.addEventListener('DOMContentLoaded',fn);}
+  function h(s){const d=document.createElement('div');d.textContent=s==null?'':String(s);return d.innerHTML;}
+  ready(async () => {
+    const list=document.getElementById('jobs-list');
+    if(!list) return;
+    const techId=window.TECH_ID;
+    const today=window.TODAY||new Date().toISOString().slice(0,10);
+    try{
+      const res=await fetch(`/api/jobs.php?start=${today}&end=${today}&status=scheduled,in_progress`,{credentials:'same-origin'});
+      const data=await res.json();
+      if(!Array.isArray(data)) throw new Error('Invalid response');
+      const jobs=data.filter(j => (j.assigned_employees||[]).some(e => Number(e.id)===Number(techId)));
+      if(!jobs.length){
+        list.innerHTML='<div class="list-group-item text-muted">No jobs for today.</div>';
+        return;
+      }
+      jobs.forEach(j => {
+        const a=document.createElement('a');
+        a.className='list-group-item list-group-item-action';
+        a.href=`tech_job.php?id=${j.job_id}`;
+        const time=j.scheduled_time?j.scheduled_time.slice(0,5):'Unscheduled';
+        a.innerHTML=`<div class="fw-bold">${h(j.customer.first_name)} ${h(j.customer.last_name)}</div>
+<small class="text-muted">${h(j.customer.address_line1||'')}</small><br>
+<small>${h(time)}</small>`;
+        list.appendChild(a);
+      });
+    }catch(err){
+      console.error(err);
+      list.innerHTML='<div class="list-group-item text-danger">Failed to load jobs.</div>';
+    }
+  });
+})();

--- a/public/tech_job.php
+++ b/public/tech_job.php
@@ -1,0 +1,47 @@
+<?php
+// /public/tech_job.php
+// Job detail view for technicians
+
+declare(strict_types=1);
+
+require __DIR__ . '/_cli_guard.php';
+require __DIR__ . '/_csrf.php';
+
+$csrf   = csrf_token();
+$techId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
+$jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Job Details</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body{padding-bottom:4.5rem}
+    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.5rem}
+  </style>
+</head>
+<body class="bg-light">
+<div class="container py-3">
+  <button class="btn btn-primary mb-3 d-none" id="btn-start-job">Start Job</button>
+  <div id="job-details" class="mb-5"></div>
+</div>
+<div class="action-bar">
+  <div class="d-flex gap-2">
+    <button class="btn btn-outline-secondary flex-fill" id="btn-add-note">Add Note</button>
+    <button class="btn btn-outline-secondary flex-fill" id="btn-add-photo">Add Photo</button>
+    <button class="btn btn-outline-secondary flex-fill" id="btn-checklist">Checklist</button>
+    <button class="btn btn-success flex-fill" id="btn-complete">Mark as Complete</button>
+  </div>
+</div>
+<script>
+  window.CSRF_TOKEN = "<?=htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8')?>";
+  window.TECH_ID = <?= $techId ?>;
+  window.JOB_ID = <?= $jobId ?>;
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/tech_job.js?v=<?=date('Ymd')?>"></script>
+</body>
+</html>

--- a/public/tech_jobs.php
+++ b/public/tech_jobs.php
@@ -1,0 +1,35 @@
+<?php
+// /public/tech_jobs.php
+// Daily job list for field technicians
+
+declare(strict_types=1);
+
+require __DIR__ . '/_cli_guard.php';
+require __DIR__ . '/_csrf.php';
+
+$csrf = csrf_token();
+$techId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
+$today = date('Y-m-d');
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Today's Jobs</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-3">
+  <h1 class="h4 mb-3">Today's Jobs</h1>
+  <div id="jobs-list" class="list-group"></div>
+</div>
+<script>
+  window.CSRF_TOKEN = "<?=htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8')?>";
+  window.TECH_ID = <?= $techId ?>;
+  window.TODAY = "<?= $today ?>";
+</script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/js/tech_jobs.js?v=<?=date('Ymd')?>"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `tech_jobs.php` to list today's assignments for field technicians
- Add `tech_job.php` with sticky action bar to manage notes, photos, checklist, and completion
- Implement `tech_jobs.js` and `tech_job.js` to call job APIs (start, notes, photos, checklist, complete)

## Testing
- `make test` *(fails: DB connection refused during integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ce0e91a8832fa2739f12271edf23