### PR TITLE
Log job completions and expose completed jobs

### DIFF
--- a/public/api/job_complete.php
+++ b/public/api/job_complete.php
@@ -96,6 +96,20 @@ try {
     $ok = Job::complete($pdo, $jobId, $lat, $lng);
     if ($ok) {
         $pdo->commit();
+        // Log completion event for auditing
+        $msg = sprintf(
+            "[%s] job_id=%d technician_id=%d status=completed\n",
+            date('c'),
+            $jobId,
+            $technicianId
+        );
+        error_log($msg, 3, __DIR__ . '/../../logs/job_events.log');
+
+        // Notify internal stakeholders about the completed job
+        $subject = 'Job Completed: #' . $jobId;
+        $body    = 'Job #' . $jobId . ' was completed by technician #' . $technicianId . ' at ' . date('c');
+        @mail('alerts@example.com', $subject, $body);
+
         JsonResponse::json(['ok' => true, 'status' => 'completed']);
     } else {
         $pdo->rollBack();

--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -28,7 +28,7 @@ try {
         $mappedStatuses[] = str_replace(' ', '_', strtolower($s));
     }
     if (!$mappedStatuses) {
-        $mappedStatuses = ['scheduled', 'assigned', 'in_progress'];
+        $mappedStatuses = ['scheduled', 'assigned', 'in_progress', 'completed'];
     }
 
     $search = trim($_GET['search'] ?? '');


### PR DESCRIPTION
## Summary
- send email notification and log to `logs/job_events.log` when a job is completed
- include completed jobs in `public/api/jobs.php` results

## Testing
- `make test` *(fails: DB connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cf96eef4832f8ebda5e115c3d117