### PR TITLE
Add shift override capability

### DIFF
--- a/public/availability_add_shift.php
+++ b/public/availability_add_shift.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
+
+header('Content-Type: application/json; charset=utf-8');
+require_once __DIR__ . '/../config/database.php';
+if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
+require_once __DIR__ . '/_csrf.php';
+
+$pdo = getPDO();
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$raw = file_get_contents('php://input');
+$data = json_decode($raw ?: '[]', true);
+if (!is_array($data)) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'invalid_json']);
+    exit;
+}
+
+if (!csrf_verify($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    http_response_code(422);
+    echo json_encode(['ok' => false, 'error' => 'invalid_csrf']);
+    exit;
+}
+
+$eid   = (int)($data['employee_id'] ?? 0);
+$date  = (string)($data['date'] ?? '');
+$start = (string)($data['start_time'] ?? '');
+$end   = (string)($data['end_time'] ?? '');
+$reason = $data['reason'] ?? null;
+
+$errors = [];
+if ($eid <= 0) $errors[] = 'employee_id';
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) $errors[] = 'date';
+if (!preg_match('/^\d{2}:\d{2}$/', $start)) $errors[] = 'start_time';
+if (!preg_match('/^\d{2}:\d{2}$/', $end)) $errors[] = 'end_time';
+if ($start >= $end) $errors[] = 'range';
+if ($errors) {
+    http_response_code(422);
+    echo json_encode(['ok' => false, 'errors' => $errors]);
+    exit;
+}
+
+$startUtc = $start . ':00';
+$endUtc   = $end . ':00';
+
+$hasType = true;
+try {
+    $col = $pdo->query("SHOW COLUMNS FROM employee_availability_overrides LIKE 'type'");
+    $hasType = (bool)$col->fetch(PDO::FETCH_ASSOC);
+} catch (Throwable $e) {
+    $hasType = true;
+}
+
+try {
+    if ($hasType) {
+        $st = $pdo->prepare("INSERT INTO employee_availability_overrides (employee_id, date, status, type, start_time, end_time, reason) VALUES (:eid,:d,'AVAILABLE','CUSTOM',:st,:et,:r)");
+        $st->execute([':eid'=>$eid, ':d'=>$date, ':st'=>$startUtc, ':et'=>$endUtc, ':r'=>$reason]);
+    } else {
+        $st = $pdo->prepare("INSERT INTO employee_availability_overrides (employee_id, date, status, start_time, end_time, reason) VALUES (:eid,:d,'AVAILABLE',:st,:et,:r)");
+        $st->execute([':eid'=>$eid, ':d'=>$date, ':st'=>$startUtc, ':et'=>$endUtc, ':r'=>$reason]);
+    }
+    $id = (int)$pdo->lastInsertId();
+
+    try {
+        $uid = $_SESSION['user']['id'] ?? null;
+        $det = json_encode(['id'=>$id,'date'=>$date,'start'=>$start,'end'=>$end,'reason'=>$reason], JSON_UNESCAPED_UNICODE);
+        $pdo->prepare('INSERT INTO availability_audit (employee_id, user_id, action, details) VALUES (:eid,:uid,:act,:det)')
+            ->execute([':eid'=>$eid, ':uid'=>$uid, ':act'=>'override_create', ':det'=>$det]);
+    } catch (Throwable $e) {
+        // ignore audit errors
+    }
+
+    echo json_encode(['ok' => true, 'id' => $id]);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['ok' => false, 'error' => 'db_error']);
+}

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -160,6 +160,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
           <div class="col-auto">
             <a href="#" class="btn btn-outline-primary disabled" id="btnProfile" aria-label="View selected employee profile" aria-disabled="true">View Profile</a>
             <button type="button" class="btn btn-success ms-2" id="btnAdd">Add Window</button>
+            <button type="button" class="btn btn-primary ms-2" id="btnAddShift">Add Shift</button>
             <button type="button" class="btn btn-warning ms-2" id="btnAddOverride">Add Override</button>
             <button type="button" class="btn btn-outline-warning ms-2" id="btnQuickPTO">PTO</button>
             <button type="button" class="btn btn-outline-info ms-2" id="btnExport">Export</button>
@@ -359,6 +360,39 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
           <button type="submit" class="btn btn-primary" id="ovSubmit">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div class="modal fade" id="shiftModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <form class="modal-content" id="shiftForm">
+        <div class="modal-header">
+          <h5 class="modal-title">Add Shift</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body row g-3">
+          <div class="col-12">
+            <label class="form-label">Date</label>
+            <input type="date" class="form-control" id="shift_date" required>
+          </div>
+          <div class="col-6">
+            <label class="form-label">Start</label>
+            <input type="time" class="form-control" id="shift_start" required>
+          </div>
+          <div class="col-6">
+            <label class="form-label">End</label>
+            <input type="time" class="form-control" id="shift_end" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label">Reason</label>
+            <input type="text" class="form-control" id="shift_reason">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Save</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add "Add Shift" button and modal to availability manager
- support creating shift overrides via availability_add_shift.php endpoint
- hook up client-side logic to submit and reload schedule

## Testing
- `vendor/bin/phpunit tests/Unit --testdox`
- `vendor/bin/phpunit tests/Integration --testdox` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d1af2de0832f915da73ff88026a6