### PR TITLE
Ensure job deletion query is portable across PDO drivers

### DIFF
--- a/models/Job.php
+++ b/models/Job.php
@@ -51,7 +51,9 @@ final class Job
      */
     public static function delete(PDO $pdo, int $jobId): int
     {
-        $st = $pdo->prepare("DELETE FROM jobs WHERE id = :id LIMIT 1");
+        $driver = (string)$pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $limitClause = in_array($driver, ['mysql', 'mariadb'], true) ? ' LIMIT 1' : '';
+        $st = $pdo->prepare('DELETE FROM jobs WHERE id = :id' . $limitClause);
         if ($st === false) {
             return 0;
         }


### PR DESCRIPTION
## Summary
- Remove hardcoded `LIMIT 1` from job deletion
- Add PDO driver check to append `LIMIT 1` only for MySQL or MariaDB

## Testing
- `vendor/bin/phpunit tests/Unit/JobModelTest.php --testdox`
- `php -r 'require "tests/support/TestPdo.php"; $pdo=createTestPdo(); echo $pdo->getAttribute(PDO::ATTR_DRIVER_NAME),"\n";'` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpstan analyse --memory-limit=1G models/Job.php`

------
https://chatgpt.com/codex/tasks/task_e_68a484ad2a78832f8d2c6f168d3bab99