### PR TITLE
Add default employment type to employees migration

### DIFF
--- a/tests/migrations/20241001020000_create_employees.sql
+++ b/tests/migrations/20241001020000_create_employees.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS employees (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
     person_id INT UNSIGNED NOT NULL,
-    employment_type VARCHAR(50) NOT NULL,
+    employment_type VARCHAR(50) NOT NULL DEFAULT 'full_time',
     hire_date DATE NOT NULL,
     status VARCHAR(20) NOT NULL,
     is_active TINYINT(1) NOT NULL DEFAULT 1,


### PR DESCRIPTION
## Summary
- default employment_type to "full_time" in employees migration

## Testing
- `php scripts/migrate_test_db.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a48c39368c832fb6e0d307ee11e045