### PR TITLE
Add assigned_at timestamp to job_employee_assignment

### DIFF
--- a/tests/migrate_test_data.php
+++ b/tests/migrate_test_data.php
@@ -71,7 +71,8 @@ $sql = [
     "CREATE TABLE IF NOT EXISTS job_employee_assignment (
         id INT AUTO_INCREMENT PRIMARY KEY,
         job_id INT NOT NULL,
-        employee_id INT NOT NULL
+        employee_id INT NOT NULL,
+        assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB",
 
     "CREATE TABLE IF NOT EXISTS job_employee (

--- a/tests/migrations/20241001070000_create_job_employee_assignment.sql
+++ b/tests/migrations/20241001070000_create_job_employee_assignment.sql
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS job_employee_assignment (
     job_id INT UNSIGNED NOT NULL,
     employee_id INT UNSIGNED NOT NULL,
+    assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (job_id, employee_id),
     CONSTRAINT fk_jea_job FOREIGN KEY (job_id) REFERENCES jobs(id)
         ON DELETE CASCADE ON UPDATE RESTRICT,


### PR DESCRIPTION
## Summary
- include `assigned_at` column with default timestamp in `job_employee_assignment` migration
- mirror the same column in the test data migration script

## Testing
- `php tests/migrate_test_data.php` *(fails: Connection refused)*
- `vendor/bin/phpunit tests/Integration/JobEmployeeViewTest.php` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a48d89f62c832fa59b2899f7427327