### PR TITLE
Add default employment_type for test employees schema

### DIFF
--- a/tests/migrate_test_data.php
+++ b/tests/migrate_test_data.php
@@ -39,7 +39,7 @@ $sql = [
     "CREATE TABLE IF NOT EXISTS employees (
         id INT AUTO_INCREMENT PRIMARY KEY,
         person_id INT NOT NULL,
-        employment_type VARCHAR(50) NOT NULL,
+        employment_type VARCHAR(50) NOT NULL DEFAULT 'full_time',
         hire_date DATE NOT NULL,
         status VARCHAR(20) NOT NULL,
         is_active TINYINT(1) NOT NULL DEFAULT 1


### PR DESCRIPTION
## Summary
- default employment_type column to `full_time` in test schema

## Testing
- `php tests/migrate_test_data.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `make unit`


------
https://chatgpt.com/codex/tasks/task_e_68a4952ccc1c832f8125bfe856165ff9