### PR TITLE
Specify employment type in assignment integration test

### DIFF
--- a/tests/Integration/AssignmentsDataTest.php
+++ b/tests/Integration/AssignmentsDataTest.php
@@ -36,9 +36,9 @@ final class AssignmentsDataTest extends TestCase
         ");
 
         $this->pdo->exec("
-            INSERT INTO employees (id, person_id)
-            VALUES (9301,9201), (9302,9202)
-            ON DUPLICATE KEY UPDATE person_id=VALUES(person_id);
+            INSERT INTO employees (id, person_id, employment_type)
+            VALUES (9301,9201,'full_time'), (9302,9202,'full_time')
+            ON DUPLICATE KEY UPDATE person_id=VALUES(person_id), employment_type=VALUES(employment_type);
         ");
     }
 


### PR DESCRIPTION
## Summary
- specify `employment_type` when seeding employees in `AssignmentsDataTest` to satisfy schema

## Testing
- `vendor/bin/phpunit tests/Integration/AssignmentsDataTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a244b9d0832fb001054c2d8ce943