### PR TITLE
refactor: simplify JobCompleteTest namespace

### DIFF
--- a/tests/Integration/JobCompleteTest.php
+++ b/tests/Integration/JobCompleteTest.php
@@ -2,17 +2,13 @@
 
 declare(strict_types=1);
 
-namespace {
-    require_once __DIR__ . '/../../config/database.php';
-    require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
-    require_once __DIR__ . '/../support/TestDataFactory.php';
-}
-
 namespace Tests\Integration;
 
-use EndpointHarness;
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+require_once __DIR__ . '/../support/TestDataFactory.php';
+
 use PHPUnit\Framework\TestCase;
-use TestDataFactory;
 
 final class JobCompleteTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- use a single unbracketed namespace in JobCompleteTest
- relocate require_once statements below namespace declaration

## Testing
- `php -l tests/Integration/JobCompleteTest.php`
- `vendor/bin/phpunit tests/Integration/JobCompleteTest.php` *(fails: `[TEST BOOTSTRAP] Migration failed: SQLSTATE[HY000] [2002] Connection refused`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4adcab6b0832f81aa4c34b3fa723e