### PR TITLE
Validate job existence in assignment process

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -21,12 +21,8 @@ if (!function_exists('getPDO')) {
         $cfg = [
             'DB_HOST' => '127.0.0.1',
             'DB_PORT' => '8889',
-<<<<<<< HEAD
             // Default to the integration DB when running in test env
-            'DB_NAME' => getenv('APP_ENV') === 'fieldops_test' ? 'fieldops_integration' : 'fieldops',
-=======
             'DB_NAME' => getenv('APP_ENV') === 'test' ? 'fieldops_integration' : 'fieldops_test',
->>>>>>> d101e92e8c7b7734a2eb996d3725beaddeecd844
             'DB_USER' => 'root',
             'DB_PASS' => 'root',
             'APP_ENV' => getenv('APP_ENV') ?: 'dev',

--- a/public/assignment_process.php
+++ b/public/assignment_process.php
@@ -55,6 +55,12 @@ try {
       $replace = !empty($data['replace']);
       if ($jobId <= 0 || empty($empIds)) throw new RuntimeException('Invalid job/employee');
 
+      $check = $pdo->prepare('SELECT 1 FROM jobs WHERE id=?');
+      $check->execute([$jobId]);
+      if (!$check->fetchColumn()) {
+        throw new RuntimeException('Job not found', 404);
+      }
+
       $pdo->beginTransaction();
       if ($replace) {
         $pdo->prepare('DELETE FROM job_employee_assignment WHERE job_id=?')->execute([$jobId]);
@@ -109,5 +115,6 @@ try {
   }
 } catch (Throwable $e) {
   if ($pdo->inTransaction()) $pdo->rollBack();
-  echo json_encode(['ok'=>false,'error'=>$e->getMessage()]);
+  $code = $e->getCode() ?: 500;
+  echo json_encode(['ok'=>false,'error'=>$e->getMessage(),'code'=>$code]);
 }


### PR DESCRIPTION
## Summary
- ensure a job exists before assigning employees
- include an error code in assignment API errors
- fix database config merge markers for tests

## Testing
- `vendor/bin/phpunit --debug tests/Integration` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7daa660832f945de440dd1c8def