### PR TITLE
Add development database configuration and migration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ The employees view displays a badge describing each worker's schedule status. Th
 - **No Hours** – no availability is defined for that day.
 
 These badges mirror the `status` and `summary` computed in `Availability::statusForEmployeesOnDate`.
+
+## Development Database
+
+To keep development data separate from integration tests, create a local MySQL
+database and run the schema migrations against it:
+
+```
+mysql -u root -p -e 'CREATE DATABASE IF NOT EXISTS fieldops_development;'
+php scripts/migrate_dev_db.php
+```
+
+The application defaults to `fieldops_development` when `APP_ENV` is `dev`.
+Connection settings can be overridden in `config/local.env.php` or via
+environment variables.

--- a/config/database.php
+++ b/config/database.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * Database connection bootstrap.
+ */
+
 declare(strict_types=1);
 
 /**
@@ -9,6 +14,7 @@ declare(strict_types=1);
  *
  * NOTE: Do NOT auto-append "_test". Set DB_NAME explicitly in local.env.php or env.
  */
+
 if (!function_exists('getPDO')) {
     function getPDO(): PDO
     {
@@ -21,8 +27,8 @@ if (!function_exists('getPDO')) {
         $cfg = [
             'DB_HOST' => '127.0.0.1',
             'DB_PORT' => '8889',
-            // Default to the integration DB when running in test env
-            'DB_NAME' => getenv('APP_ENV') === 'test' ? 'fieldops_integration' : 'fieldops_test',
+            // Default to the integration DB in tests, otherwise use the development DB
+            'DB_NAME' => getenv('APP_ENV') === 'test' ? 'fieldops_integration' : 'fieldops_development',
             'DB_USER' => 'root',
             'DB_PASS' => 'root',
             'APP_ENV' => getenv('APP_ENV') ?: 'dev',

--- a/config/local.env.php
+++ b/config/local.env.php
@@ -1,7 +1,8 @@
 <?php
+
 // Define variables (do NOT return an array)
 $DB_HOST = '127.0.0.1';
 $DB_PORT = '8889';
-$DB_NAME = 'fieldops_test';
+$DB_NAME = 'fieldops_development';
 $DB_USER = 'root';
 $DB_PASS = 'root';

--- a/scripts/migrate_dev_db.php
+++ b/scripts/migrate_dev_db.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/migrate_test_db.php';
+
+$host = getenv('DB_HOST') ?: '127.0.0.1';
+$port = getenv('DB_PORT') ?: '8889';
+$db   = getenv('DB_NAME') ?: 'fieldops_development';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: 'root';
+
+$pdo = new PDO(
+    "mysql:host={$host};port={$port};dbname={$db};charset=utf8mb4",
+    $user,
+    $pass,
+    [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    ]
+);
+
+migrateTestDb($pdo);


### PR DESCRIPTION
## Summary
- Default to `fieldops_development` when running in dev environment
- Document how to create and migrate a separate development database
- Provide `migrate_dev_db.php` wrapper for running migrations locally

## Testing
- `vendor/bin/phpcs config/database.php config/local.env.php scripts/migrate_dev_db.php`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4daea3b60832fbdc71c0d28058156