### PR TITLE
Add admin interface for managing job types

### DIFF
--- a/models/JobType.php
+++ b/models/JobType.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+final class JobType
+{
+    /**
+     * Fetch all job types.
+     *
+     * @return list<array{id:int|string,name:string}>
+     */
+    public static function all(PDO $pdo): array
+    {
+        $st = $pdo->prepare('SELECT id, name FROM job_types ORDER BY name, id');
+        if ($st === false) {
+            return [];
+        }
+        $st->execute();
+        /** @var list<array{id:int|string,name:string}> $rows */
+        $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+        return $rows;
+    }
+
+    /**
+     * Find a job type by id.
+     *
+     * @return array{id:int,name:string}|null
+     */
+    public static function find(PDO $pdo, int $id): ?array
+    {
+        $st = $pdo->prepare('SELECT id, name FROM job_types WHERE id = :id');
+        if ($st === false) {
+            return null;
+        }
+        $st->execute([':id' => $id]);
+        $row = $st->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        return ['id' => (int)$row['id'], 'name' => (string)$row['name']];
+    }
+
+    /**
+     * Create a new job type. Returns inserted id.
+     */
+    public static function create(PDO $pdo, string $name): int
+    {
+        $st = $pdo->prepare('INSERT INTO job_types (name) VALUES (:name)');
+        $st->execute([':name' => $name]);
+        return (int)$pdo->lastInsertId();
+    }
+
+    /**
+     * Update an existing job type. Returns true if a row was updated.
+     */
+    public static function update(PDO $pdo, int $id, string $name): bool
+    {
+        $st = $pdo->prepare('UPDATE job_types SET name = :name WHERE id = :id');
+        $st->execute([':name' => $name, ':id' => $id]);
+        return $st->rowCount() > 0;
+    }
+
+    /**
+     * Delete a job type by id. Returns true if a row was deleted.
+     */
+    public static function delete(PDO $pdo, int $id): bool
+    {
+        $st = $pdo->prepare('DELETE FROM job_types WHERE id = :id');
+        $st->execute([':id' => $id]);
+        return $st->rowCount() > 0;
+    }
+}

--- a/public/admin/job_type_form.php
+++ b/public/admin/job_type_form.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/JobType.php';
+require_once __DIR__ . '/../_csrf.php';
+
+$pdo = getPDO();
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$jobType = $id > 0 ? JobType::find($pdo, $id) : null;
+$__csrf = csrf_token();
+$title = $id > 0 ? 'Edit Job Type' : 'Add Job Type';
+require_once __DIR__ . '/../../partials/header.php';
+require_once __DIR__ . '/nav.php';
+?>
+<form method="post" action="/admin/job_type_save.php" class="card p-3" autocomplete="off">
+  <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($__csrf, ENT_QUOTES, 'UTF-8') ?>">
+  <?php if ($id > 0): ?>
+    <input type="hidden" name="id" value="<?= (int)$id ?>">
+    <input type="hidden" name="action" value="update">
+  <?php else: ?>
+    <input type="hidden" name="action" value="create">
+  <?php endif; ?>
+  <div class="mb-3">
+    <label class="form-label" for="name">Name</label>
+    <input type="text" class="form-control" id="name" name="name" required value="<?= htmlspecialchars($jobType['name'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+  </div>
+  <div class="mt-3">
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="/admin/job_type_list.php" class="btn btn-secondary">Cancel</a>
+  </div>
+</form>
+<?php require_once __DIR__ . '/../../partials/footer.php'; ?>

--- a/public/admin/job_type_list.php
+++ b/public/admin/job_type_list.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/JobType.php';
+require_once __DIR__ . '/../_csrf.php';
+
+$pdo = getPDO();
+$types = JobType::all($pdo);
+$__csrf = csrf_token();
+$title = 'Job Types';
+require_once __DIR__ . '/../../partials/header.php';
+require_once __DIR__ . '/nav.php';
+?>
+<div class="d-flex mb-3">
+  <a href="/admin/job_type_form.php" class="btn btn-primary ms-auto">Add Job Type</a>
+</div>
+<div class="card">
+  <div class="table-responsive">
+    <table class="table table-striped table-hover m-0">
+      <thead class="table-light">
+        <tr>
+          <th>ID</th>
+          <th>Name</th>
+          <th class="text-end">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+      <?php foreach ($types as $t): ?>
+        <tr>
+          <td><?= (int)$t['id'] ?></td>
+          <td><?= htmlspecialchars((string)$t['name'], ENT_QUOTES, 'UTF-8') ?></td>
+          <td class="text-end">
+            <a href="/admin/job_type_form.php?id=<?= (int)$t['id'] ?>" class="btn btn-sm btn-outline-secondary">Edit</a>
+            <form method="post" action="/admin/job_type_save.php" class="d-inline" onsubmit="return confirm('Delete this job type?');">
+              <input type="hidden" name="id" value="<?= (int)$t['id'] ?>">
+              <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($__csrf, ENT_QUOTES, 'UTF-8') ?>">
+              <button type="submit" name="action" value="delete" class="btn btn-sm btn-outline-danger">Delete</button>
+            </form>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+      <?php if (!$types): ?>
+        <tr><td colspan="3" class="text-center text-muted py-4">No job types found.</td></tr>
+      <?php endif; ?>
+      </tbody>
+    </table>
+  </div>
+</div>
+<?php require_once __DIR__ . '/../../partials/footer.php'; ?>

--- a/public/admin/job_type_save.php
+++ b/public/admin/job_type_save.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_csrf();
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/JobType.php';
+
+$pdo = getPDO();
+$action = $_POST['action'] ?? '';
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$name = trim((string)($_POST['name'] ?? ''));
+
+switch ($action) {
+    case 'create':
+        if ($name !== '') { JobType::create($pdo, $name); }
+        break;
+    case 'update':
+        if ($id > 0 && $name !== '') { JobType::update($pdo, $id, $name); }
+        break;
+    case 'delete':
+        if ($id > 0) { JobType::delete($pdo, $id); }
+        break;
+}
+header('Location: /admin/job_type_list.php');
+exit;

--- a/public/admin/nav.php
+++ b/public/admin/nav.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+?>
+<nav class="mb-3">
+  <a href="/admin/job_type_list.php" class="me-3">Job Types</a>
+</nav>


### PR DESCRIPTION
## Summary
- add JobType model with CRUD helpers
- create admin job type management pages
- include admin nav linking to job type list

## Testing
- `make unit`
- `make integration` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `make lint` *(fails: Found 244 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f5eb0504832f9835e9b01d73ad9c