### PR TITLE
Add skill CRUD operations and admin management pages

### DIFF
--- a/models/Skill.php
+++ b/models/Skill.php
@@ -45,4 +45,81 @@ final class Skill
             return [];
         }
     }
+
+    /**
+     * Find a single skill by id.
+     *
+     * @return array{id:int|string,name:string}|null
+     */
+    public static function find(PDO $pdo, int $id): ?array
+    {
+        try {
+            $st = $pdo->prepare('SELECT id, name FROM skills WHERE id = :id');
+            if ($st === false) {
+                return null;
+            }
+            $st->execute([':id' => $id]);
+            /** @var array{id:int|string,name:string}|false $row */
+            $row = $st->fetch(PDO::FETCH_ASSOC);
+            return $row === false ? null : $row;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Create a new skill and return its id on success.
+     *
+     * @return int|false
+     */
+    public static function create(PDO $pdo, string $name)
+    {
+        try {
+            $st = $pdo->prepare('INSERT INTO skills (name) VALUES (:name)');
+            if ($st === false) {
+                return false;
+            }
+            $ok = $st->execute([':name' => $name]);
+            if (!$ok) {
+                return false;
+            }
+            /** @var int|string $id */
+            $id = $pdo->lastInsertId();
+            return is_numeric($id) ? (int)$id : false;
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Update an existing skill name.
+     */
+    public static function update(PDO $pdo, int $id, string $name): bool
+    {
+        try {
+            $st = $pdo->prepare('UPDATE skills SET name = :name WHERE id = :id');
+            if ($st === false) {
+                return false;
+            }
+            return $st->execute([':name' => $name, ':id' => $id]);
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Delete a skill by id.
+     */
+    public static function delete(PDO $pdo, int $id): bool
+    {
+        try {
+            $st = $pdo->prepare('DELETE FROM skills WHERE id = :id');
+            if ($st === false) {
+                return false;
+            }
+            return $st->execute([':id' => $id]);
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
 }

--- a/public/admin/skill_form.php
+++ b/public/admin/skill_form.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/Skill.php';
+require_once __DIR__ . '/../_csrf.php';
+
+$pdo = getPDO();
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$skill = $id > 0 ? Skill::find($pdo, $id) : null;
+$__csrf = csrf_token();
+
+function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title><?= $id > 0 ? 'Edit Skill' : 'Add Skill' ?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-3">
+  <h1 class="h4 mb-4"><?= $id > 0 ? 'Edit Skill' : 'Add Skill' ?></h1>
+  <?php if ($id > 0 && !$skill): ?>
+    <p>Skill not found.</p>
+  <?php else: ?>
+  <form method="post" action="skill_save.php" autocomplete="off" class="needs-validation" novalidate>
+    <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
+    <?php if ($id > 0): ?><input type="hidden" name="id" value="<?= (int)$id ?>"><?php endif; ?>
+    <div class="mb-3">
+      <label for="name" class="form-label">Name</label>
+      <input type="text" id="name" name="name" class="form-control" value="<?= s($skill['name'] ?? '') ?>" required>
+      <div class="invalid-feedback">Name is required.</div>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="skill_list.php" class="btn btn-secondary ms-2">Cancel</a>
+  </form>
+  <?php endif; ?>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+(() => {
+  'use strict';
+  const forms = document.querySelectorAll('.needs-validation');
+  Array.from(forms).forEach(form => {
+    form.addEventListener('submit', event => {
+      if (!form.checkValidity()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      form.classList.add('was-validated');
+    }, false);
+  });
+})();
+</script>
+</body>
+</html>

--- a/public/admin/skill_list.php
+++ b/public/admin/skill_list.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/Skill.php';
+require_once __DIR__ . '/../_csrf.php';
+
+$pdo = getPDO();
+/** @var list<array{id:int|string,name:string}> $skills */
+$skills = Skill::all($pdo);
+$__csrf = csrf_token();
+
+function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Skills</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-3">
+  <div class="d-flex align-items-center mb-3">
+    <h1 class="h4 m-0">Skills</h1>
+    <a href="skill_form.php" class="btn btn-sm btn-primary ms-auto">Add Skill</a>
+  </div>
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-striped table-hover m-0">
+        <thead class="table-light">
+          <tr><th>ID</th><th>Name</th><th class="text-end">Actions</th></tr>
+        </thead>
+        <tbody>
+        <?php foreach ($skills as $sk): ?>
+          <tr>
+            <td><?= (int)$sk['id'] ?></td>
+            <td><?= s($sk['name']) ?></td>
+            <td class="text-end">
+              <a href="skill_form.php?id=<?= (int)$sk['id'] ?>" class="btn btn-sm btn-outline-secondary">Edit</a>
+              <form method="post" action="skill_save.php" class="d-inline" onsubmit="return confirm('Delete this skill?');">
+                <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
+                <input type="hidden" name="id" value="<?= (int)$sk['id'] ?>">
+                <input type="hidden" name="delete" value="1">
+                <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+              </form>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/public/admin/skill_save.php
+++ b/public/admin/skill_save.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/Skill.php';
+require_once __DIR__ . '/../_csrf.php';
+
+if (($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+    http_response_code(405);
+    echo 'Method Not Allowed';
+    exit;
+}
+
+$raw   = file_get_contents('php://input');
+$data  = array_merge($_GET, $_POST);
+$token = (string)($data['csrf_token'] ?? '');
+if (!csrf_verify($token)) {
+    csrf_log_failure_payload($raw, $data);
+    http_response_code(422);
+    echo 'Invalid CSRF token';
+    exit;
+}
+
+$pdo  = getPDO();
+$id   = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$name = trim((string)($_POST['name'] ?? ''));
+$isDelete = isset($_POST['delete']);
+
+if ($isDelete) {
+    if ($id > 0) {
+        Skill::delete($pdo, $id);
+    }
+    header('Location: skill_list.php');
+    exit;
+}
+
+if ($name === '') {
+    header('Location: ' . ($id > 0 ? 'skill_form.php?id=' . $id : 'skill_form.php'));
+    exit;
+}
+
+if ($id > 0) {
+    Skill::update($pdo, $id, $name);
+} else {
+    Skill::create($pdo, $name);
+}
+
+header('Location: skill_list.php');
+exit;

--- a/public/employees.php
+++ b/public/employees.php
@@ -108,6 +108,7 @@ $searchQuery = $search !== null && $search !== '' ? '&search=' . urlencode($sear
   <div class="d-flex align-items-center mb-3">
     <h1 class="h4 m-0 me-2">Employees</h1>
     <a href="add_employee.php" class="btn btn-sm btn-primary ms-auto">Add New</a>
+    <a href="/admin/skill_list.php" class="btn btn-sm btn-secondary ms-2">Skills</a>
   </div>
   <div class="mb-3">
     <select id="skill-filter" class="form-select" multiple>


### PR DESCRIPTION
## Summary
- add find/create/update/delete helpers to Skill model
- create admin pages to list, edit, and save skills with CSRF protection
- link employee list to new skill management section

## Testing
- `vendor/bin/phpunit` *(fails: Migration failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f75664a8832f8b3f99e4a48c720f