### PR TITLE
Restrict admin nav and test non-admin access

### DIFF
--- a/public/admin/nav.php
+++ b/public/admin/nav.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
 ?>
 <nav class="mb-3">
   <a href="/admin/job_type_list.php" class="me-3">Job Types</a>

--- a/tests/Integration/AdminPageAuthTest.php
+++ b/tests/Integration/AdminPageAuthTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class AdminPageAuthTest extends TestCase
+{
+    public function testNonAdminIsForbidden(): void
+    {
+        $target = __DIR__ . '/../../public/admin/job_type_list.php';
+        $tmp = tempnam(sys_get_temp_dir(), 'fo');
+        $php = <<<'PHP'
+<?php
+session_id('t-' . bin2hex(random_bytes(3)));
+session_start();
+$_SESSION['role'] = 'dispatcher';
+define('FIELDOPS_ALLOW_ENDPOINT_EXECUTION', true);
+$GLOBALS['__FIELDOPS_TEST_CALL__'] = true;
+require '%s';
+PHP;
+        $code = sprintf($php, addslashes($target));
+        file_put_contents($tmp, $code);
+        $out = shell_exec('php ' . escapeshellarg($tmp));
+        unlink($tmp);
+        $res = json_decode((string)$out, true);
+        $this->assertFalse($res['ok'] ?? true);
+        $this->assertSame(403, $res['code'] ?? 0);
+    }
+}
+


### PR DESCRIPTION
## Summary
- require authentication and admin role in admin navigation
- add integration test ensuring non-admins get 403 from admin pages

## Testing
- `./vendor/bin/phpunit tests/Integration/AdminPageAuthTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a4fa80dc98832fb2342564723ea8e4