### PR TITLE
Ensure API model includes use require_once

### DIFF
--- a/public/api/job_checklist.php
+++ b/public/api/job_checklist.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobChecklistItem.php';
+require_once __DIR__ . '/../../models/JobChecklistItem.php';
 
 $raw  = file_get_contents('php://input');
 $data = array_merge($_GET, $_POST);

--- a/public/api/job_checklist_update.php
+++ b/public/api/job_checklist_update.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobChecklistItem.php';
+require_once __DIR__ . '/../../models/JobChecklistItem.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {

--- a/public/api/job_complete.php
+++ b/public/api/job_complete.php
@@ -6,10 +6,10 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/Job.php';
-require __DIR__ . '/../../models/JobNote.php';
-require __DIR__ . '/../../models/JobPhoto.php';
-require __DIR__ . '/../../models/JobCompletion.php';
+require_once __DIR__ . '/../../models/Job.php';
+require_once __DIR__ . '/../../models/JobNote.php';
+require_once __DIR__ . '/../../models/JobPhoto.php';
+require_once __DIR__ . '/../../models/JobCompletion.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {

--- a/public/api/job_notes_add.php
+++ b/public/api/job_notes_add.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobNote.php';
+require_once __DIR__ . '/../../models/JobNote.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {

--- a/public/api/job_notes_list.php
+++ b/public/api/job_notes_list.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobNote.php';
+require_once __DIR__ . '/../../models/JobNote.php';
 
 $raw  = file_get_contents('php://input');
 $data = array_merge($_GET, $_POST);

--- a/public/api/job_photos_delete.php
+++ b/public/api/job_photos_delete.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobPhoto.php';
+require_once __DIR__ . '/../../models/JobPhoto.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {

--- a/public/api/job_photos_upload.php
+++ b/public/api/job_photos_upload.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/JobPhoto.php';
+require_once __DIR__ . '/../../models/JobPhoto.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {

--- a/public/api/job_start.php
+++ b/public/api/job_start.php
@@ -5,7 +5,7 @@ require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../_auth.php';
 require __DIR__ . '/../_csrf.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/Job.php';
+require_once __DIR__ . '/../../models/Job.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {

--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 // /public/api/jobs.php
 require __DIR__ . '/../_cli_guard.php';
 require __DIR__ . '/../../config/database.php';
-require __DIR__ . '/../../models/Job.php';
+require_once __DIR__ . '/../../models/Job.php';
 
 header('Content-Type: application/json');
 

--- a/public/jobs.php
+++ b/public/jobs.php
@@ -14,7 +14,7 @@ if (!isset($_SESSION['csrf_token'])) {
 $CSRF = $_SESSION['csrf_token'];
 
 require __DIR__ . '/../config/database.php';
-require __DIR__ . '/../models/Job.php';
+require_once __DIR__ . '/../models/Job.php';
 
 $pdo = getPDO();
 $statuses = Job::allowedStatuses();


### PR DESCRIPTION
## Summary
- Prevent duplicate class declarations by switching model includes in API endpoints to `require_once`
- Apply the same change across related job endpoints and the jobs page

## Testing
- `APP_ENV=test ./vendor/bin/phpunit tests/Integration/TechnicianJobFlowTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fd7ce614832f8eb522466877b3e5