### PR TITLE
Allow admin role in dev login

### DIFF
--- a/public/dev_login.php
+++ b/public/dev_login.php
@@ -59,7 +59,7 @@ if ($appEnv !== 'dev' && !$loose) {
 
 // Seed role
 $role = $_GET['role'] ?? 'dispatcher';
-if (!in_array($role, ['dispatcher','field_tech'], true)) {
+if (!in_array($role, ['dispatcher','field_tech','admin'], true)) {
     $role = 'dispatcher';
 }
 $id = (isset($_GET['id']) && ctype_digit($_GET['id'])) ? (int)$_GET['id'] : null;


### PR DESCRIPTION
## Summary
- permit admin role in dev login shim by adding admin to whitelist

## Testing
- `php -l public/dev_login.php`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `curl -c cookies.txt "http://localhost:8010/dev_login.php?role=admin&loose=1"` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68a50a23696c832f80825a456025facc