### PR TITLE
Start session if inactive before admin skill list

### DIFF
--- a/public/admin/skill_list.php
+++ b/public/admin/skill_list.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 require __DIR__ . '/../_cli_guard.php';
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
 require_once __DIR__ . '/../_auth.php';
 require_role('admin');
 require_once __DIR__ . '/../../config/database.php';


### PR DESCRIPTION
## Summary
- Ensure session is started before loading admin skill list

## Testing
- `make serve-bg` and `curl -s -D - http://127.0.0.1:8010/admin/skill_list.php | head -n 20`
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `make lint` *(fails: 258 phpstan errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a50befc3b8832fb7827efd5fbe1d86