### PR TITLE
Ensure skill form starts a session

### DIFF
--- a/public/admin/skill_form.php
+++ b/public/admin/skill_form.php
@@ -1,6 +1,9 @@
 <?php
 declare(strict_types=1);
 require __DIR__ . '/../_cli_guard.php';
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
 require_once __DIR__ . '/../_auth.php';
 require_role('admin');
 require_once __DIR__ . '/../../config/database.php';


### PR DESCRIPTION
## Summary
- Start a session in admin skill form when one isn't active to prevent unauthorized 403 responses

## Testing
- `php -l public/admin/skill_form.php`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `curl -b /tmp/cookie.txt -i 'http://127.0.0.1:8000/admin/skill_form.php'` *(HTTP 200 with DB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68a50e832838832fa7ed34a9472e4b89