### PR TITLE
Expose customer details on job detail API

### DIFF
--- a/models/Job.php
+++ b/models/Job.php
@@ -8,8 +8,8 @@ final class Job
      */
     public static function getJobAndCustomerDetails(PDO $pdo, int $jobId): ?array
     {
-        $st = $pdo->prepare("
-            SELECT
+        $st = $pdo->prepare(
+            "SELECT
                 j.id,
                 j.customer_id,
                 j.description,
@@ -17,22 +17,53 @@ final class Job
                 j.scheduled_date,
                 j.scheduled_time,
                 j.duration_minutes,
-                c.id   AS customer_id_actual,
-                CONCAT(c.first_name, ' ', c.last_name) AS customer_name,
-                c.email AS customer_email,
-                c.phone AS customer_phone
+                c.id            AS customer_id_actual,
+                c.first_name    AS customer_first_name,
+                c.last_name     AS customer_last_name,
+                c.email         AS customer_email,
+                c.phone         AS customer_phone,
+                c.address_line1,
+                c.address_line2,
+                c.city,
+                c.state,
+                c.postal_code,
+                c.country
             FROM jobs j
             JOIN customers c ON c.id = j.customer_id
             WHERE j.id = :id
-            LIMIT 1
-        ");
+            LIMIT 1"
+        );
         if ($st === false) {
             return null;
         }
         $st->execute([':id' => $jobId]);
         /** @var array<string,mixed>|false $row */
         $row = $st->fetch(PDO::FETCH_ASSOC);
-        return $row !== false ? $row : null;
+        if ($row === false) {
+            return null;
+        }
+        return [
+            'id' => (int)$row['id'],
+            'customer_id' => (int)$row['customer_id'],
+            'description' => $row['description'],
+            'status' => $row['status'],
+            'scheduled_date' => $row['scheduled_date'],
+            'scheduled_time' => $row['scheduled_time'],
+            'duration_minutes' => $row['duration_minutes'] !== null ? (int)$row['duration_minutes'] : null,
+            'customer' => [
+                'id' => (int)$row['customer_id_actual'],
+                'first_name' => $row['customer_first_name'],
+                'last_name' => $row['customer_last_name'],
+                'email' => $row['customer_email'],
+                'phone' => $row['customer_phone'],
+                'address_line1' => $row['address_line1'],
+                'address_line2' => $row['address_line2'],
+                'city' => $row['city'],
+                'state' => $row['state'],
+                'postal_code' => $row['postal_code'],
+                'country' => $row['country'],
+            ],
+        ];
     }
 
     /**

--- a/public/api/get_job_details.php
+++ b/public/api/get_job_details.php
@@ -11,8 +11,8 @@ header('Content-Type: application/json');
 $pdo = getPDO();
 $id  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
-$row    = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
+$job    = $id > 0 ? Job::getJobAndCustomerDetails($pdo, $id) : null;
 $notes  = $id > 0 ? JobNote::listForJob($pdo, $id) : [];
 $photos = $id > 0 ? JobPhoto::listForJob($pdo, $id) : [];
 
-echo json_encode(['ok' => (bool)$row, 'job' => $row, 'notes' => $notes, 'photos' => $photos], JSON_UNESCAPED_SLASHES);
+echo json_encode(['ok' => (bool)$job, 'job' => $job, 'notes' => $notes, 'photos' => $photos], JSON_UNESCAPED_SLASHES);

--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -24,8 +24,8 @@
         if(!data?.ok) throw new Error('Job not found');
         const j=data.job;
         details.innerHTML=`<h1 class="h5">${h(j.description||'')}</h1>
-<div>${h(j.customer.first_name||'')} ${h(j.customer.last_name||'')}</div>
-<div class="text-muted">${h(j.customer.address_line1||'')}</div>`;
+<div>${h(j.customer?.first_name||'')} ${h(j.customer?.last_name||'')}</div>
+<div class="text-muted">${h(j.customer?.address_line1||'')}</div>`;
         if(j.status==='scheduled'){btnStart.classList.remove('d-none');}
       })
       .catch(err=>{details.innerHTML=`<div class="text-danger">${h(err.message)}</div>`;});


### PR DESCRIPTION
## Summary
- Provide full customer information in Job::getJobAndCustomerDetails and return structured `customer` data
- Update job details API to return the new structured job payload
- Safely read customer fields in tech job page using optional chaining

## Testing
- `make unit`
- `make test` *(fails: Migration failed: SQLSTATE[HY000] [2002] Connection refused)*
- `make lint` *(fails: Found 257 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d184eb88832fa44b7f1d7396c78b