### PR TITLE
Verify job ownership before start

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -449,6 +449,7 @@ ensureColumn($pdo, 'jobs', 'started_at', 'DATETIME NULL');
 ensureColumn($pdo, 'jobs', 'completed_at', 'DATETIME NULL');
 ensureColumn($pdo, 'jobs', 'location_lat', 'DECIMAL(10,6) NULL');
 ensureColumn($pdo, 'jobs', 'location_lng', 'DECIMAL(10,6) NULL');
+ensureColumn($pdo, 'jobs', 'technician_id', 'INT NULL');
 
 out(PHP_EOL . "== Ensuring UNIQUE indexes ==");
 ensureUnique($pdo, 'employee_availability', ['employee_id','day_of_week','start_time','end_time'], 'uq_availability_window');

--- a/tests/Integration/TechnicianJobFlowTest.php
+++ b/tests/Integration/TechnicianJobFlowTest.php
@@ -30,14 +30,15 @@ final class TechnicianJobFlowTest extends TestCase
 
         $customerId   = TestDataFactory::createCustomer($this->pdo);
         $this->techId = TestDataFactory::createEmployee($this->pdo);
-        $this->jobId  = TestDataFactory::createJob(
+        $this->jobId = TestDataFactory::createJob(
             $this->pdo,
             $customerId,
             'Technician flow job',
             '2025-01-01',
             '09:00:00',
             60,
-            'assigned'
+            'assigned',
+            $this->techId
         );
 
         $st = $this->pdo->prepare('INSERT INTO job_checklist_items (job_id, description, is_completed) VALUES (:j,:d,0)');
@@ -74,7 +75,7 @@ final class TechnicianJobFlowTest extends TestCase
                 'location_lat' => '1',
                 'location_lng' => '2',
             ],
-            ['role' => 'technician']
+            ['role' => 'technician', 'user' => ['id' => $this->techId]]
         );
         $this->assertTrue($start['ok'] ?? false);
         $this->assertSame('in_progress', $start['status'] ?? null);

--- a/tests/migrations/20241001050000_create_jobs.sql
+++ b/tests/migrations/20241001050000_create_jobs.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     scheduled_date DATE NOT NULL,
     scheduled_time TIME NOT NULL,
     duration_minutes INT NOT NULL,
+    technician_id INT UNSIGNED NULL,
     started_at DATETIME NULL,
     completed_at DATETIME NULL,
     location_lat DECIMAL(10,6) NULL,
@@ -13,5 +14,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NULL,
     CONSTRAINT fk_jobs_customer FOREIGN KEY (customer_id) REFERENCES customers(id)
-        ON DELETE RESTRICT ON UPDATE CASCADE
+        ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT fk_jobs_technician FOREIGN KEY (technician_id) REFERENCES employees(id)
+        ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- ensure job start API only allows the assigned technician to begin a job
- add optional technician_id column for jobs and helper support
- adjust technician flow test to include technician assignments

## Testing
- `vendor/bin/phpunit` *(fails: DB connection refused, AdminPageAuthTest failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8480188832fb09dd265ec9b8e7d