### PR TITLE
Use POST-only data for job start

### DIFF
--- a/public/api/job_start.php
+++ b/public/api/job_start.php
@@ -14,7 +14,7 @@ if ($method !== 'POST') {
 }
 
 $raw  = file_get_contents('php://input');
-$data = array_merge($_GET, $_POST);
+$data = $_POST;
 if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     csrf_log_failure_payload($raw, $data);
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);


### PR DESCRIPTION
## Summary
- Job start endpoint now reads request data only from `$_POST`

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db31f604832fa20174856666db93