### PR TITLE
Require final note and photos before job completion

### DIFF
--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -187,8 +187,10 @@
 
     btnComplete?.addEventListener('click',async()=>{
       if(!confirm('Mark job complete?')) return;
-      const finalNote=prompt('Enter final note:')||'';
+      const finalNote=(prompt('Enter final note:')||'').trim();
+      if(!finalNote){alert('Final note is required');return;}
       const photos=await pickFinalPhotos();
+      if(!photos?.length){alert('At least one completion photo is required');return;}
       const signature=await captureSignature();
       if(!signature){alert('Signature required');return;}
       btnComplete.disabled=true;


### PR DESCRIPTION
## Summary
- Ensure final note is provided when marking job complete
- Require at least one completion photo before signature and submission

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e6f3eb6c832f8f42eee71eed6bd8