### PR TITLE
Improve job completion UX in tech job page

### DIFF
--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -208,10 +208,21 @@
         const res=await fetch('/api/job_complete.php',{method:'POST',body:fd,credentials:'same-origin'});
         const data=await res.json();
         if(!data?.ok) throw new Error(data?.error||'Failed');
-        alert('Job completed');
+        if(window.FieldOpsToast && typeof FieldOpsToast.show==='function'){
+          FieldOpsToast.show('Job completed');
+        }else{
+          alert('Job completed');
+        }
+        btnComplete.disabled=true;
+        btnComplete.classList.add('d-none');
+        if(details){
+          const status=document.createElement('div');
+          status.className='mt-2 badge bg-success';
+          status.textContent='Completed';
+          details.appendChild(status);
+        }
       }catch(err){
         alert(err.message||'Failed');
-      }finally{
         btnComplete.disabled=false;
       }
     });


### PR DESCRIPTION
## Summary
- Hide "Job Complete" button and display completion badge after finishing a job
- Show toast confirmation instead of alert

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpcs` *(fails: existing style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eaab9b80832f9a4684baaf44c2ec