### PR TITLE
Add shared navbar and unify page layouts

### DIFF
--- a/partials/footer.php
+++ b/partials/footer.php
@@ -11,6 +11,7 @@ if (!defined('FOOTER_INCLUDED')) {
             integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
             crossorigin="anonymous"></script>
     <script src="/js/toast.js"></script>
+    <?= $pageScripts ?? '' ?>
 
     <script>
     // No-op shims so modal calls never error if page-specific refresh isn't defined

--- a/partials/header.php
+++ b/partials/header.php
@@ -4,6 +4,8 @@ if (!defined('HEADER_INCLUDED')) {
     define('HEADER_INCLUDED', true);
 }
 $title = $title ?? 'FieldOps';
+$headExtra = $headExtra ?? '';
+$bodyAttrs = isset($bodyAttrs) && $bodyAttrs !== '' ? ' ' . $bodyAttrs : '';
 ?>
 <!doctype html>
 <html lang="en">
@@ -21,8 +23,10 @@ $title = $title ?? 'FieldOps';
   <!-- Optional: app styles -->
   <link rel="stylesheet" href="/css/app.css">
   <link rel="icon" type="image/png" href="/favicon.png">
+  <?= $headExtra ?>
 </head>
-<body class="bg-light">
+<body class="bg-light"<?= $bodyAttrs ?>>
+  <?php require __DIR__ . '/navbar.php'; ?>
   <div class="container-fluid py-4">
     <header class="mb-4">
       <h1 class="h3"><?= htmlspecialchars($title) ?></h1>

--- a/partials/navbar.php
+++ b/partials/navbar.php
@@ -1,0 +1,31 @@
+<?php
+// /partials/navbar.php
+// Bootstrap 5 navbar with active link highlighting
+
+$current = basename($_SERVER['SCRIPT_NAME'] ?? '');
+$items = [
+    'jobs.php' => 'Jobs',
+    'employees.php' => 'Employees',
+    'customers.php' => 'Customers',
+    'assignments.php' => 'Assignments',
+    'availability_manager.php' => 'Availability',
+];
+?>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/jobs.php">FieldOps</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <?php foreach ($items as $file => $label): ?>
+          <?php $active = $current === $file ? 'active' : ''; ?>
+          <li class="nav-item">
+            <a class="nav-link <?= $active ?>" href="/<?= $file ?>"><?= htmlspecialchars($label) ?></a>
+          </li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/public/assignments.php
+++ b/public/assignments.php
@@ -5,20 +5,10 @@ require __DIR__ . '/_cli_guard.php';
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 if (!isset($_SESSION['csrf_token'])) { $_SESSION['csrf_token'] = bin2hex(random_bytes(16)); }
 $CSRF = $_SESSION['csrf_token'];
+ $title = 'Assignments';
+ require __DIR__ . '/../partials/header.php';
 ?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Assignments</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container py-3">
-  <div class="d-flex align-items-center mb-3">
-    <h1 class="h4 m-0 me-2">Assignments</h1>
-  </div>
+
   <div class="mb-3">
     <input type="search" id="filter-search" class="form-control form-control-sm" placeholder="Search jobs or customers">
   </div>
@@ -39,10 +29,12 @@ $CSRF = $_SESSION['csrf_token'];
       </table>
     </div>
   </div>
-</div>
+
 <?php include __DIR__ . '/../partials/assignments_modal.php'; ?>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<?php
+$pageScripts = <<<HTML
 <script src="/js/assignments.js"></script>
 <script src="/js/assignments-page.js"></script>
-</body>
-</html>
+HTML;
+require __DIR__ . '/../partials/footer.php';
+?>

--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -101,15 +101,9 @@ if (($_GET['action'] ?? '') === 'log') {
 
 // Selected employee id from query string (if any)
 $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 0;
-?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Availability Manager</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Bootstrap 5 -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
+$title = 'Availability Manager';
+$bodyAttrs = 'data-csrf="' . s($__csrf) . '"';
+$headExtra = <<<HTML
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
   <style>
     body { padding: 24px; }
@@ -117,8 +111,9 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
     .table thead th { position: sticky; top: 0; background: #fff; z-index: 1; }
     #calendar { max-width: 100%; }
   </style>
-</head>
-<body data-csrf="<?= s($__csrf) ?>">
+HTML;
+require __DIR__ . '/../partials/header.php';
+?>
   <div class="container-xxl">
     <nav aria-label="breadcrumb" class="mb-3">
       <ol class="breadcrumb mb-0">
@@ -131,12 +126,11 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
       </ol>
     </nav>
     <div class="d-flex align-items-center justify-content-between mb-3">
+      <div id="weekDisplay" class="text-muted small"></div>
       <div>
-        <h1 class="h3 mb-0">Availability Manager</h1>
-        <div id="weekDisplay" class="text-muted small"></div>
+        <a href="availability_form.php" class="btn btn-outline-secondary btn-sm">Classic Form</a>
+        <a href="availability_onboard.php?employee_id=<?= $selectedEmployeeId ?: '' ?>&week_start=<?= s($weekStart) ?>" class="btn btn-outline-primary btn-sm ms-2">Setup Wizard</a>
       </div>
-      <a href="availability_form.php" class="btn btn-outline-secondary btn-sm">Classic Form</a>
-      <a href="availability_onboard.php?employee_id=<?= $selectedEmployeeId ?: '' ?>&week_start=<?= s($weekStart) ?>" class="btn btn-outline-primary btn-sm ms-2">Setup Wizard</a>
     </div>
 
     <div id="alertBox" class="alert d-none" role="alert"></div>
@@ -518,10 +512,11 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
       </div>
     </div>
   </template>
-
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
-  <script src="/js/toast.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
-  <script type="module" src="/js/availability-manager.js"></script>
-</body>
-</html>
+</div>
+<?php
+$pageScripts = <<<HTML
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
+<script type="module" src="/js/availability-manager.js"></script>
+HTML;
+require __DIR__ . '/../partials/footer.php';
+?>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,6 @@
+/* Custom global styles */
+
+/* Highlight active nav link */
+.navbar-nav .nav-link.active {
+    font-weight: 600;
+}

--- a/public/customers.php
+++ b/public/customers.php
@@ -37,20 +37,12 @@ function sort_link(string $label, string $column, array $params, string $sort, s
     return '<a href="/customers.php?' . s($qs) . '">' . s($label) . $arrow . '</a>';
 }
 $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort, $dir);
+$title = 'Customers';
+require __DIR__ . '/../partials/header.php';
 ?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Customers</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container py-3">
-  <div class="d-flex align-items-center mb-3">
-    <h1 class="h4 m-0">Customers</h1>
-    <a href="/customer_form.php" class="btn btn-sm btn-primary ms-auto">Add Customer</a>
+
+  <div class="mb-3 text-end">
+    <a href="/customer_form.php" class="btn btn-sm btn-primary">Add Customer</a>
   </div>
 
   <form class="mb-3" method="get">
@@ -105,9 +97,9 @@ $rows = CustomerDataProvider::getFiltered($pdo, $q, $city, $state, $limit, $sort
       </table>
     </div>
   </div>
-</div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <?php require_once __DIR__ . '/../partials/flash_toast.php'; ?>
-</body>
-</html>
+<?php
+$pageScripts = '';
+require __DIR__ . '/../partials/footer.php';
+?>

--- a/public/employees.php
+++ b/public/employees.php
@@ -92,22 +92,17 @@ $skillQuery = '';
 foreach ($skills as $s) { $skillQuery .= '&skills[]=' . urlencode($s); }
 $searchQuery = $search !== null && $search !== '' ? '&search=' . urlencode($search) : '';
 ?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Employees</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+$title = 'Employees';
+$headExtra = <<<HTML
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-  <link href="css/skills.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-<div class="container py-3">
-  <div class="d-flex align-items-center mb-3">
-    <h1 class="h4 m-0 me-2">Employees</h1>
-    <a href="add_employee.php" class="btn btn-sm btn-primary ms-auto">Add New</a>
+  <link href="/css/skills.css" rel="stylesheet">
+HTML;
+require __DIR__ . '/../partials/header.php';
+?>
+
+  <div class="mb-3 text-end">
+    <a href="add_employee.php" class="btn btn-sm btn-primary">Add New</a>
     <a href="/admin/skill_list.php" class="btn btn-sm btn-secondary ms-2">Skills</a>
   </div>
   <div class="mb-3">
@@ -228,13 +223,15 @@ $searchQuery = $search !== null && $search !== '' ? '&search=' . urlencode($sear
     <span class="badge bg-danger ms-3 me-1">Booked</span> Booked
     <span class="badge bg-warning text-dark ms-3 me-1">Partially Booked</span> Partially Booked
   </div>
-</div>
+$pageScripts = <<<HTML
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="/js/toast.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script src="/js/employees.js"></script>
+HTML;
+ob_start();
+?>
 <script>
-$(function(){
+document.addEventListener('DOMContentLoaded', function(){
   const searchForm=document.getElementById('search-form');
   const searchInput=document.getElementById('employee-search');
   searchForm.addEventListener('submit',function(e){
@@ -277,5 +274,7 @@ $(function(){
   tooltipTriggerList.map(el=>new bootstrap.Tooltip(el));
 });
 </script>
-</body>
-</html>
+<?php
+$pageScripts .= ob_get_clean();
+require __DIR__ . '/../partials/footer.php';
+?>

--- a/public/jobs.php
+++ b/public/jobs.php
@@ -20,14 +20,9 @@ $pdo = getPDO();
 $statuses = Job::allowedStatuses();
 $today = date('Y-m-d');
 $weekLater = date('Y-m-d', strtotime('+7 days'));
-?>
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Jobs</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+
+$title = 'Jobs';
+$headExtra = <<<HTML
   <style>
     .jobs-toolbar{gap:.5rem;flex-wrap:wrap}
     .table-jobs th{white-space:nowrap}
@@ -35,11 +30,11 @@ $weekLater = date('Y-m-d', strtotime('+7 days'));
     .badge-status{text-transform:capitalize}
     .sticky-header thead th{position:sticky;top:0;z-index:1}
   </style>
-</head>
-<body class="bg-light">
-<div class="container py-3">
+HTML;
+require __DIR__ . '/../partials/header.php';
+?>
+
   <div class="d-flex align-items-center mb-3">
-    <h1 class="h4 m-0 me-2">Jobs</h1>
     <div class="ms-auto">
       <a href="add_job.php" class="btn btn-primary btn-sm">+ Add Job</a>
     </div>
@@ -92,11 +87,12 @@ $weekLater = date('Y-m-d', strtotime('+7 days'));
       </table>
     </div>
   </div>
-</div>
 
 <?php include __DIR__ . '/../partials/assignments_modal.php'; ?>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<?php
+$pageScripts = <<<HTML
 <script src="/js/assignments.js?v=20250812"></script>
 <script src="/js/jobs.js?v=20250812"></script>
-</body>
-</html>
+HTML;
+require __DIR__ . '/../partials/footer.php';
+?>


### PR DESCRIPTION
## Summary
- add Bootstrap-based navbar partial with active link highlighting
- update header/footer to support navbar, extra head content and page scripts
- refactor jobs, employees, customers, assignments, and availability manager pages to use layout partials
- add app.css for navbar styling

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68a5ec0981bc832fb86231f6ad7f6e2d