### PR TITLE
Toggle job buttons by status

### DIFF
--- a/public/tech_job.php
+++ b/public/tech_job.php
@@ -33,7 +33,7 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     <button class="btn btn-outline-secondary flex-fill" id="btn-add-note">Add Note</button>
     <button class="btn btn-outline-secondary flex-fill" id="btn-add-photo">Add Photo</button>
     <button class="btn btn-outline-secondary flex-fill" id="btn-checklist">Checklist</button>
-    <button class="btn btn-success flex-fill" id="btn-complete">Mark as Complete</button>
+    <button class="btn btn-success flex-fill d-none" id="btn-complete">Mark as Complete</button>
   </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Hide "Mark as Complete" button by default
- Toggle job action buttons based on fetched status and update status after starting

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `make lint` *(fails: found 261 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f50e7bf4832fa11e3459415c5cb9