### PR TITLE
Ensure employees footer scripts execute

### DIFF
--- a/public/employees.php
+++ b/public/employees.php
@@ -223,6 +223,7 @@ require __DIR__ . '/../partials/header.php';
     <span class="badge bg-danger ms-3 me-1">Booked</span> Booked
     <span class="badge bg-warning text-dark ms-3 me-1">Partially Booked</span> Partially Booked
   </div>
+<?php
 $pageScripts = <<<HTML
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>


### PR DESCRIPTION
## Summary
- Re-enter PHP mode before `$pageScripts` in `public/employees.php` so footer scripts are captured

## Testing
- `php -l public/employees.php`
- `vendor/bin/phpunit` *(fails: DB connection refused)*
- Manual footer render snippet to ensure scripts output

------
https://chatgpt.com/codex/tasks/task_e_68a5f8b33dc8832f81ef14cac9dcdba3