### PR TITLE
Log errors when starting jobs

### DIFF
--- a/public/api/job_start.php
+++ b/public/api/job_start.php
@@ -57,6 +57,7 @@ try {
         JsonResponse::json(['ok' => false, 'error' => 'Invalid status', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
     }
 } catch (Throwable $e) {
+    error_log('job_start: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
     JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
 }
 


### PR DESCRIPTION
## Summary
- Log exceptions in `job_start` API to aid debugging, including stack traces

## Testing
- `php public/test_db_info.php` *(fails: Connection refused)*
- `vendor/bin/phpunit` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6070b1554832f843ff612bc1482f6