### PR TITLE
Add SRI attributes to employee page scripts

### DIFF
--- a/public/employees.php
+++ b/public/employees.php
@@ -224,11 +224,17 @@ require __DIR__ . '/../partials/header.php';
     <span class="badge bg-warning text-dark ms-3 me-1">Partially Booked</span> Partially Booked
   </div>
 <?php
-// Note: When adding new CDN-hosted scripts, include integrity hashes and
-// crossorigin="anonymous" to enable Subresource Integrity (SRI).
+// Note: When adding new CDN-hosted scripts, always include integrity hashes
+// and crossorigin="anonymous" to enable Subresource Integrity (SRI).
 $pageScripts = <<<HTML
-<script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-K+XTx5ZfNcaRvbn8NKiSAyOfE7wsBhb1kKEuWiRiwXg=" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js" integrity="sha256-K+ctZ5MkRUYw35vj0IadB1iKsFcfoTmya4A1NVuMcZV=" crossorigin="anonymous"></script>
+<script
+  src="https://code.jquery.com/jquery-3.6.0.min.js"
+  integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
+  crossorigin="anonymous"></script>
+<script
+  src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"
+  integrity="sha256-K+ctZ5MkRUYw35vj0IadB1iKsFcfoTmya4A1NVuMcZV="
+  crossorigin="anonymous"></script>
 <script>window.CSRF_TOKEN = '{$CSRF}';</script>
 <script src="/js/employees.js"></script>
 HTML;


### PR DESCRIPTION
## Summary
- ensure external scripts on employees page include SRI and CORS attributes
- document SRI requirement for future CDN scripts
- correct jQuery SRI hash to match CDN

## Testing
- `make test` *(fails: DB connection refused)*
- `make lint` *(fails: Found 260 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6079776a4832fb00e7bab690ac69c