### PR TITLE
Fix start job button visibility for assigned status

### DIFF
--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -32,8 +32,9 @@
         statusEl=document.getElementById('job-status');
 
         if(statusEl){statusEl.textContent=`Status: ${fmtStatus(j.status)}`;}
-        if(j.status==='assigned'){btnStart.classList.remove('d-none');}
-        if(j.status==='in_progress'){btnComplete.classList.remove('d-none');}
+        const status=(j.status||'').toLowerCase();
+        if(status==='assigned'){btnStart.classList.remove('d-none');}
+        if(status==='in_progress'){btnComplete.classList.remove('d-none');}
 
       })
       .catch(err=>{details.innerHTML=`<div class="text-danger">${h(err.message)}</div>`;});


### PR DESCRIPTION
## Summary
- Normalize job status check on tech job page to be case-insensitive

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a61075aec8832f8e6c655de1b7962f