### PR TITLE
Fix job start assignment check with fallback

### DIFF
--- a/tests/Integration/JobStartAssignmentFallbackTest.php
+++ b/tests/Integration/JobStartAssignmentFallbackTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+require_once __DIR__ . '/../support/TestDataFactory.php';
+
+final class JobStartAssignmentFallbackTest extends TestCase
+{
+    private PDO $pdo;
+    private int $jobId;
+    private int $techId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = getPDO();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec('DELETE FROM job_employee_assignment');
+        $this->pdo->exec('DELETE FROM jobs');
+        $this->pdo->exec('DELETE FROM employees');
+        $this->pdo->exec('DELETE FROM people');
+        $this->pdo->exec('DELETE FROM customers');
+
+        $customerId = TestDataFactory::createCustomer($this->pdo);
+        $this->techId = TestDataFactory::createEmployee($this->pdo);
+
+        // Insert job with technician_id NULL but assignment via join table
+        $stmt = $this->pdo->prepare("INSERT INTO jobs (customer_id, description, status, scheduled_date, scheduled_time, duration_minutes, technician_id) VALUES (:c,:d,'assigned','2025-01-01','09:00:00',60,NULL)");
+        $stmt->execute([':c' => $customerId, ':d' => 'Fallback job']);
+        $this->jobId = (int)$this->pdo->lastInsertId();
+
+        $this->pdo->prepare('INSERT INTO job_employee_assignment (job_id, employee_id) VALUES (:j,:e)')
+            ->execute([':j' => $this->jobId, ':e' => $this->techId]);
+    }
+
+    public function testFallbackToAssignmentTableWhenTechnicianIdColumnEmpty(): void
+    {
+        $res = EndpointHarness::run(
+            __DIR__ . '/../../public/api/job_start.php',
+            [
+                'job_id' => $this->jobId,
+                'location_lat' => '1',
+                'location_lng' => '2',
+            ],
+            ['role' => 'technician', 'user' => ['id' => $this->techId]]
+        );
+
+        $this->assertTrue($res['ok'] ?? false);
+        $this->assertSame('in_progress', $res['status'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- check job_employee_assignment when `jobs.technician_id` does not match the current technician
- add integration test covering fallback behaviour

## Testing
- `php -d memory_limit=1G vendor/bin/phpunit tests/Integration/JobStartAssignmentFallbackTest.php` *(fails: DB connection refused)*
- `php -d memory_limit=1G vendor/bin/phpstan analyse --memory-limit=1G` *(fails: 262 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6206f4d6c832fb423693e363b21a0