### PR TITLE
feat: mobile tech jobs layout

### DIFF
--- a/public/js/tech_jobs.js
+++ b/public/js/tech_jobs.js
@@ -2,33 +2,66 @@
 (() => {
   function ready(fn){document.readyState!=='loading'?fn():document.addEventListener('DOMContentLoaded',fn);}
   function h(s){const d=document.createElement('div');d.textContent=s==null?'':String(s);return d.innerHTML;}
+  function fmtStatus(s){return (s||'').replace(/_/g,' ');}  
+  function truncate(str,len){str=String(str||'');return str.length>len?str.slice(0,len-1)+'\u2026':str;}
   ready(async () => {
     const list=document.getElementById('jobs-list');
-    if(!list) return;
+    const banner=document.getElementById('date-banner');
     const techId=window.TECH_ID;
     const today=window.TODAY||new Date().toISOString().slice(0,10);
+    if(banner){banner.textContent=window.TODAY_HUMAN||'';}
+
+    const btnNote=document.getElementById('btn-add-note');
+    const btnPhoto=document.getElementById('btn-add-photo');
+    const btnMap=document.getElementById('btn-map-view');
+    const fileInput=document.createElement('input');
+    fileInput.type='file';
+    fileInput.accept='image/*';
+    fileInput.style.display='none';
+    document.body.appendChild(fileInput);
+    btnNote?.addEventListener('click',()=>alert('Add Note tapped'));
+    btnPhoto?.addEventListener('click',()=>fileInput.click());
+    fileInput.addEventListener('change',()=>{if(fileInput.files[0]){alert('Photo selected');fileInput.value='';}});
+    btnMap?.addEventListener('click',()=>alert('Map view coming soon'));
+
+    if(!list) return;
     try{
       const res=await fetch(`/api/jobs.php?start=${today}&end=${today}&status=in_progress,assigned`,{credentials:'same-origin'});
       const data=await res.json();
       if(!Array.isArray(data)) throw new Error('Invalid response');
       const jobs=data.filter(j => (j.assigned_employees||[]).some(e => Number(e.id)===Number(techId)));
       if(!jobs.length){
-        list.innerHTML='<div class="list-group-item text-muted">No jobs for today.</div>';
+        list.innerHTML='<div class="text-center text-muted py-5">No jobs for today.</div>';
         return;
       }
       jobs.forEach(j => {
-        const a=document.createElement('a');
-        a.className='list-group-item list-group-item-action';
-        a.href=`tech_job.php?id=${j.job_id}`;
+        const card=document.createElement('div');
+        card.className='card mb-3 shadow-sm';
         const time=j.scheduled_time?j.scheduled_time.slice(0,5):'Unscheduled';
-        a.innerHTML=`<div class="fw-bold">${h(j.customer.first_name)} ${h(j.customer.last_name)}</div>
-<small class="text-muted">${h(j.customer.address_line1||'')}</small><br>
-<small>${h(time)}</small>`;
-        list.appendChild(a);
+        const type=(j.job_skills&&j.job_skills[0]?.name)||'';
+        const address=[j.customer.address_line1,j.customer.city].filter(Boolean).join(', ');
+        const truncAddr=truncate(address,40);
+        const statusColor={assigned:'secondary',in_progress:'info',completed:'success'}[(j.status||'').toLowerCase()]||'secondary';
+        card.innerHTML=`<div class="card-body">
+          <div class="d-flex justify-content-between">
+            <div>
+              <div class="fw-bold">${h(j.customer.first_name)} ${h(j.customer.last_name)}</div>
+              <div class="text-muted small">${h(truncAddr)}</div>
+              <div class="small">${h(time)} &middot; ${h(type)}</div>
+            </div>
+            <span class="badge bg-${statusColor}">${h(fmtStatus(j.status))}</span>
+          </div>
+          <div class="mt-3 d-flex gap-2">
+            <a class="btn btn-outline-primary flex-fill" target="_blank" href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}">Go</a>
+            <a class="btn btn-primary flex-fill" href="tech_job.php?id=${j.job_id}">View Details</a>
+          </div>
+        </div>`;
+        list.appendChild(card);
       });
     }catch(err){
       console.error(err);
-      list.innerHTML='<div class="list-group-item text-danger">Failed to load jobs.</div>';
+      list.innerHTML='<div class="text-center text-danger py-5">Failed to load jobs.</div>';
     }
   });
 })();
+

--- a/public/tech_jobs.php
+++ b/public/tech_jobs.php
@@ -18,16 +18,39 @@ $today = date('Y-m-d');
   <title>Today's Jobs</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body{padding-bottom:4.5rem}
+    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.5rem}
+  </style>
 </head>
 <body class="bg-light">
+<nav class="navbar navbar-light bg-white border-bottom sticky-top">
+  <div class="container-fluid align-items-center">
+    <button class="navbar-toggler" type="button" id="menu-button">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <span class="navbar-brand mx-auto">FieldOps</span>
+    <div class="ms-auto">
+      <span class="rounded-circle bg-secondary d-block" style="width:40px;height:40px;"></span>
+    </div>
+  </div>
+  <div class="bg-light w-100 text-center small py-1" id="date-banner"></div>
+</nav>
 <div class="container py-3">
-  <h1 class="h4 mb-3">Today's Jobs</h1>
-  <div id="jobs-list" class="list-group"></div>
+  <div id="jobs-list"></div>
+</div>
+<div class="action-bar">
+  <div class="d-flex gap-2">
+    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-note">+ Add Note</button>
+    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-photo">+ Photo</button>
+    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-map-view">MapView</button>
+  </div>
 </div>
 <script>
   window.CSRF_TOKEN = "<?=htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8')?>";
   window.TECH_ID = <?= $techId ?>;
   window.TODAY = "<?= $today ?>";
+  window.TODAY_HUMAN = "<?= date('l, F j') ?>";
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="/js/tech_jobs.js?v=<?=date('Ymd')?>"></script>


### PR DESCRIPTION
## Summary
- add mobile header with menu, profile and date for tech job list
- render jobs as cards with status badges and quick actions
- include sticky bottom bar for notes, photos and map view

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a62bee50b4832f891bfb0c03e67a61