### PR TITLE
Enhance tech job view with notes, photos, and status banner

### DIFF
--- a/public/api/job_photos_list.php
+++ b/public/api/job_photos_list.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require __DIR__ . '/../_auth.php';
+require __DIR__ . '/../_csrf.php';
+require __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/JobPhoto.php';
+
+$raw  = file_get_contents('php://input');
+$data = array_merge($_GET, $_POST);
+if (!verify_csrf_token($data['csrf_token'] ?? null)) {
+    csrf_log_failure_payload($raw, $data);
+    JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
+    return;
+}
+
+if (current_role() === 'guest') {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
+$jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
+if ($jobId <= 0) {
+    JsonResponse::json(['ok' => false, 'error' => 'Missing job_id', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+try {
+    $pdo    = getPDO();
+    $photos = JobPhoto::listForJob($pdo, $jobId);
+    JsonResponse::json(['ok' => true, 'photos' => $photos]);
+} catch (Throwable $e) {
+    JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+}
+

--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -8,12 +8,15 @@
   const techId=Number(window.TECH_ID);
   ready(() => {
     const details=document.getElementById('job-details');
+    const notesEl=document.getElementById('job-notes');
+    const photosEl=document.getElementById('job-photos');
+    const statusBanner=document.getElementById('status-banner');
     const btnStart=document.getElementById('btn-start-job');
     const btnNote=document.getElementById('btn-add-note');
     const btnPhoto=document.getElementById('btn-add-photo');
     const btnChecklist=document.getElementById('btn-checklist');
     const btnComplete=document.getElementById('btn-complete');
-    let statusEl;
+    let scheduledStart=null;
     const fileInput=document.createElement('input');
     fileInput.type='file';
     fileInput.accept='image/*';
@@ -44,26 +47,90 @@
       log.appendChild(div);
     }
 
+    function updateStatus(st){
+      if(!statusBanner) return;
+      const map={assigned:'secondary',in_progress:'warning',completed:'success'};
+      const cls=map[st]||'secondary';
+      statusBanner.className=`alert alert-${cls} mb-3`;
+      statusBanner.textContent=fmtStatus(st);
+      statusBanner.classList.remove('d-none');
+    }
+
+    function isTooEarly(){
+      return scheduledStart && new Date()<scheduledStart;
+    }
+
+    function fetchNotes(){
+      fetch(`/api/job_notes_list.php?job_id=${jobId}&csrf_token=${encodeURIComponent(csrf)}`,{credentials:'same-origin'})
+        .then(r=>r.json())
+        .then(data=>{if(!data?.ok) throw new Error();renderNotes(data.notes||[]);})
+        .catch(()=>{if(notesEl) notesEl.innerHTML='<div class="text-muted">No notes</div>';});
+    }
+
+    function renderNotes(notes){
+      if(!notesEl) return;
+      if(!notes.length){notesEl.innerHTML='<div class="text-muted">No notes</div>';return;}
+      notesEl.innerHTML='';
+      notes.forEach(n=>{
+        const div=document.createElement('div');
+        div.className='mb-2';
+        div.innerHTML=`<div>${h(n.note)}</div><div class="text-muted small">${h(new Date(n.created_at).toLocaleString())}</div>`;
+        notesEl.appendChild(div);
+      });
+    }
+
+    function fetchPhotos(){
+      fetch(`/api/job_photos_list.php?job_id=${jobId}&csrf_token=${encodeURIComponent(csrf)}`,{credentials:'same-origin'})
+        .then(r=>r.json())
+        .then(data=>{if(!data?.ok) throw new Error();renderPhotos(data.photos||[]);})
+        .catch(()=>{if(photosEl) photosEl.innerHTML='<div class="text-muted">No photos</div>';});
+    }
+
+    function renderPhotos(photos){
+      if(!photosEl) return;
+      photosEl.innerHTML='';
+      if(!photos.length){photosEl.innerHTML='<div class="text-muted">No photos</div>';return;}
+      photos.forEach(p=>{
+        const img=document.createElement('img');
+        img.src=`/${p.path}`;
+        img.className='img-thumbnail';
+        img.style.maxWidth='120px';
+        photosEl.appendChild(img);
+      });
+    }
+
     fetch(`/api/get_job_details.php?id=${jobId}`,{credentials:'same-origin'})
       .then(r=>r.json())
       .then(data=>{
         if(!data?.ok) throw new Error('Job not found');
         const j=data.job;
-        details.innerHTML=`<h1 class="h5">${h(j.description||'')}</h1>
-<div>${h(j.customer?.first_name||'')} ${h(j.customer?.last_name||'')}</div>
-<div class="text-muted">${h(j.customer?.address_line1||'')}</div>
-<div id="job-status" class="text-muted"></div>`;
-        statusEl=document.getElementById('job-status');
-
-        if(statusEl){statusEl.textContent=`Status: ${fmtStatus(j.status)}`;}
+        const c=j.customer||{};
+        const addr=[c.address_line1,c.city,c.state,c.postal_code].filter(Boolean).join(', ');
+        const mapUrl=`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(addr)}`;
+        const callUrl=c.phone?`tel:${c.phone}`:'#';
+        const start=j.scheduled_time?new Date(`${j.scheduled_date}T${j.scheduled_time}`):null;
+        const end=start?new Date(start.getTime()+((j.duration_minutes||60)*60000)):null;
+        const win=start?`${start.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})} - ${end.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}`:'';
+        details.innerHTML=`<div class="mb-2 fw-bold">Job #${h(j.id)}</div>
+<div>${h(c.first_name||'')} ${h(c.last_name||'')}</div>
+<div>${h(c.address_line1||'')}</div>
+<div class="mb-2"><a class="btn btn-sm btn-outline-primary me-2" href="${mapUrl}" target="_blank">Directions</a>${c.phone?`<a class="btn btn-sm btn-outline-primary" href="${callUrl}">Call</a>`:''}</div>
+<div class="text-muted mb-2">${h(win)}</div>
+<div class="fst-italic">${h(j.description||'')}</div>`;
+        scheduledStart=start;
+        updateStatus(j.status);
         const status=(j.status||'').toLowerCase();
         if(status==='assigned'){btnStart.classList.remove('d-none');}
         if(status==='in_progress'){btnComplete.classList.remove('d-none');}
-
+        if(isTooEarly()){btnStart.classList.add('disabled');}else{btnStart.classList.remove('disabled');}
+        fetchNotes();
+        fetchPhotos();
+        setInterval(()=>{if(btnStart&&btnStart.classList.contains('disabled')&&!isTooEarly())btnStart.classList.remove('disabled');},60000);
       })
       .catch(err=>{details.innerHTML=`<div class="text-danger">${h(err.message)}</div>`;});
 
     btnStart?.addEventListener('click',()=>{
+      if(isTooEarly() && !confirm('Start before scheduled time?')){return;}
       btnStart.disabled=true;
       navigator.geolocation.getCurrentPosition(pos=>{
         const fd=new FormData();
@@ -75,10 +142,9 @@
           .then(r=>r.json())
           .then(res=>{
             if(!res?.ok) throw new Error(res?.error||'Failed');
-
             btnStart.classList.add('d-none');
             btnComplete.classList.remove('d-none');
-            if(statusEl){statusEl.textContent=`Status: ${fmtStatus(res.status||'in_progress')}`;}
+            updateStatus(res.status||'in_progress');
           })
           .catch(err=>{alert(err.message||'Failed');btnStart.disabled=false;});
       },()=>{alert('Location required');btnStart.disabled=false;});
@@ -93,7 +159,7 @@
       fd.append('note',note);
       fd.append('csrf_token',csrf);
       fetch('/api/job_notes_add.php',{method:'POST',body:fd,credentials:'same-origin'})
-        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');alert('Note added');})
+        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');fetchNotes();})
         .catch(err=>alert(err.message||'Failed'));
     });
 
@@ -106,7 +172,7 @@
       fd.append('photo',fileInput.files[0]);
       fd.append('csrf_token',csrf);
       fetch('/api/job_photos_upload.php',{method:'POST',body:fd,credentials:'same-origin'})
-        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');alert('Photo uploaded');fileInput.value='';})
+        .then(r=>r.json()).then(res=>{if(!res?.ok) throw new Error(res?.error||'Failed');fileInput.value='';fetchPhotos();})
         .catch(err=>{alert(err.message||'Upload failed');fileInput.value='';});
     });
 
@@ -282,12 +348,7 @@
         }
         btnComplete.disabled=true;
         btnComplete.classList.add('d-none');
-        if(details){
-          const status=document.createElement('div');
-          status.className='mt-2 badge bg-success';
-          status.textContent='Completed';
-          details.appendChild(status);
-        }
+        updateStatus('completed');
         debugStep('Completion workflow finished');
       }catch(err){
         alert(err.message||'Failed');

--- a/public/tech_job.php
+++ b/public/tech_job.php
@@ -19,21 +19,32 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    body{padding-bottom:4.5rem}
-    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.5rem}
+    body{padding-bottom:6rem}
+    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.75rem;z-index:1000}
+    .action-bar .btn{padding:1rem;font-size:1.25rem}
+    #btn-start-job.disabled{opacity:.65;pointer-events:auto}
   </style>
 </head>
 <body class="bg-light">
 <div class="container py-3">
+  <div id="status-banner" class="alert alert-secondary mb-3 d-none"></div>
   <button class="btn btn-primary mb-3 d-none" id="btn-start-job">Start Job</button>
-  <div id="job-details" class="mb-5"></div>
+  <div id="job-details" class="mb-4"></div>
+  <div id="notes-section" class="mb-4">
+    <h2 class="h6">Notes</h2>
+    <div id="job-notes" class="small"></div>
+  </div>
+  <div id="photos-section" class="mb-4">
+    <h2 class="h6">Photos</h2>
+    <div id="job-photos" class="d-flex flex-wrap gap-2"></div>
+  </div>
 </div>
 <div class="action-bar">
   <div class="d-flex gap-2">
-    <button class="btn btn-outline-secondary flex-fill" id="btn-add-note">Add Note</button>
-    <button class="btn btn-outline-secondary flex-fill" id="btn-add-photo">Add Photo</button>
-    <button class="btn btn-outline-secondary flex-fill" id="btn-checklist">Checklist</button>
-    <button class="btn btn-success flex-fill d-none" id="btn-complete">Mark as Complete</button>
+    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-add-note">Add Note</button>
+    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-add-photo">Add Photo</button>
+    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-checklist">Checklist</button>
+    <button class="btn btn-success flex-fill btn-lg d-none" id="btn-complete">Mark as Complete</button>
   </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Show job metadata, notes, and photos on technician job page
- Add API endpoint to list job photos
- Refresh status banner and handle early job starts with confirmation

## Testing
- `make lint` *(fails: Found 275 errors)*
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a62d2926d0832fb21cb82a8cd0e470