### PR TITLE
Improve accessibility and time formatting

### DIFF
--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -3,6 +3,8 @@
   function ready(fn){document.readyState!=='loading'?fn():document.addEventListener('DOMContentLoaded',fn);}
   function h(s){const d=document.createElement('div');d.textContent=s==null?'':String(s);return d.innerHTML;}
   function fmtStatus(s){return (s||'').replace(/_/g,' ');}
+  const timeFmt=new Intl.DateTimeFormat([], {hour:'numeric',minute:'numeric'});
+  const dateTimeFmt=new Intl.DateTimeFormat([], {dateStyle:'medium',timeStyle:'short'});
   const csrf=window.CSRF_TOKEN;
   const jobId=Number(window.JOB_ID);
   const techId=Number(window.TECH_ID);
@@ -76,7 +78,7 @@
 
     const fab=document.createElement('div');
     fab.className='fab';
-    fab.innerHTML=`<div class="fab-menu d-none"><button class="btn btn-light" id="fab-note">Note</button><button class="btn btn-light" id="fab-photo">Photo</button></div><button class="btn btn-primary fab-main">+</button>`;
+    fab.innerHTML=`<div class="fab-menu d-none"><button class="btn btn-light" id="fab-note" aria-label="Add note">Note</button><button class="btn btn-light" id="fab-photo" aria-label="Add photo">Photo</button></div><button class="btn btn-primary fab-main" aria-label="Toggle quick actions">+</button>`;
     document.body.appendChild(fab);
     const fabMenu=fab.querySelector('.fab-menu');
     fab.querySelector('.fab-main').addEventListener('click',()=>fabMenu.classList.toggle('d-none'));
@@ -134,7 +136,7 @@
       notes.forEach(n=>{
         const div=document.createElement('div');
         div.className='mb-2';
-        div.innerHTML=`<div>${h(n.note)}</div><div class="text-muted small">${h(new Date(n.created_at).toLocaleString())}</div>`;
+        div.innerHTML=`<div>${h(n.note)}</div><div class="text-muted small">${h(dateTimeFmt.format(new Date(n.created_at)))}</div>`;
         notesEl.appendChild(div);
       });
     }
@@ -170,7 +172,7 @@
         const callUrl=c.phone?`tel:${c.phone}`:'#';
         const start=j.scheduled_time?new Date(`${j.scheduled_date}T${j.scheduled_time}`):null;
         const end=start?new Date(start.getTime()+((j.duration_minutes||60)*60000)):null;
-        const win=start?`${start.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})} - ${end.toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}`:'';
+        const win=start?`${timeFmt.format(start)} - ${timeFmt.format(end)}`:'';
         details.innerHTML=`<div class="mb-2 fw-bold">Job #${h(j.id)}</div>
 <div>${h(c.first_name||'')} ${h(c.last_name||'')}</div>
 <div>${h(c.address_line1||'')}</div>
@@ -270,19 +272,27 @@
     async function showChecklistModal(items){
       return new Promise(resolve=>{
         const modal=document.createElement('div');
+        const titleId='chkModalTitle';
         modal.className='modal fade';
-        modal.innerHTML=`<div class="modal-dialog"><div class="modal-content">
-<div class="modal-header"><h5 class="modal-title">Checklist</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
-<div class="modal-body"></div>
-<div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button><button type="button" class="btn btn-primary" id="chk-save">Save</button></div>
+        modal.setAttribute('tabindex','-1');
+        modal.setAttribute('role','dialog');
+        modal.setAttribute('aria-modal','true');
+        modal.setAttribute('aria-labelledby',titleId);
+        modal.innerHTML=`<div class="modal-dialog" role="document"><div class="modal-content">
+<div class="modal-header"><h5 id="${titleId}" class="modal-title">Checklist</h5><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+<div class="modal-body" role="list"></div>
+<div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Close">Close</button><button type="button" class="btn btn-primary" id="chk-save" aria-label="Save checklist">Save</button></div>
 </div></div>`;
         const body=modal.querySelector('.modal-body');
         items.forEach((it,i)=>{
           const id='chk'+i;
           const div=document.createElement('div');
-          div.className='form-check';
+          div.className='form-check mb-2';
+          div.setAttribute('role','listitem');
           div.innerHTML=`<input class="form-check-input" type="checkbox" id="${id}" ${it.completed?'checked':''}>
 <label class="form-check-label" for="${id}">${h(it.item||it.description||'')}</label>`;
+          const cb=div.querySelector('input');
+          cb.setAttribute('aria-label',it.item||it.description||'');
           body.appendChild(div);
         });
         document.body.appendChild(modal);
@@ -294,14 +304,20 @@
           bsModal.hide();resolve(res);
         });
         bsModal.show();
+        modal.addEventListener('shown.bs.modal',()=>{modal.querySelector('input,textarea,select,button')?.focus();},{once:true});
       });
     }
 
     async function showNoteModal(){
       return new Promise(resolve=>{
         const modal=document.createElement('div');
+        const titleId='noteModalTitle';
         modal.className='modal fade';
-        modal.innerHTML=`<div class="modal-dialog"><div class="modal-content"><div class="modal-header"><h5 class="modal-title">Add Note</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div><div class="modal-body"><textarea class="form-control" id="note-text" rows="4"></textarea><button type="button" class="btn btn-sm btn-secondary mt-2" id="voice-btn">Voice</button></div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button><button type="button" class="btn btn-primary" id="note-save">Save</button></div></div></div>`;
+        modal.setAttribute('tabindex','-1');
+        modal.setAttribute('role','dialog');
+        modal.setAttribute('aria-modal','true');
+        modal.setAttribute('aria-labelledby',titleId);
+        modal.innerHTML=`<div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><h5 id="${titleId}" class="modal-title">Add Note</h5><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body"><textarea class="form-control" id="note-text" rows="4"></textarea><button type="button" class="btn btn-sm btn-secondary mt-2" id="voice-btn" aria-label="Voice input">Voice</button></div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Cancel">Cancel</button><button type="button" class="btn btn-primary" id="note-save" aria-label="Save note">Save</button></div></div></div>`;
         document.body.appendChild(modal);
         const bsModal=new bootstrap.Modal(modal);
         const textarea=modal.querySelector('#note-text');
@@ -317,6 +333,7 @@
           recog.start();
         });
         bsModal.show();
+        modal.addEventListener('shown.bs.modal',()=>{textarea.focus();},{once:true});
       });
     }
 
@@ -324,12 +341,17 @@
       return new Promise(resolve=>{
         const modal=document.createElement('div');
         modal.className='modal fade';
+        modal.setAttribute('tabindex','-1');
+        modal.setAttribute('role','dialog');
+        modal.setAttribute('aria-modal','true');
+        const titleId='photoModalTitle';
+        modal.setAttribute('aria-labelledby',titleId);
         let bodyHtml='';
         files.forEach((f,i)=>{
           const url=URL.createObjectURL(f);
           bodyHtml+=`<div class="mb-3"><img src="${url}" class="img-fluid mb-1"><select class="form-select mb-1" data-idx="${i}"><option>Before</option><option>After</option><option>Other</option></select><input type="text" class="form-control" placeholder="Annotation (optional)" data-anno="${i}"></div>`;
         });
-        modal.innerHTML=`<div class="modal-dialog"><div class="modal-content"><div class="modal-header"><h5 class="modal-title">Upload Photos</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div><div class="modal-body">${bodyHtml}</div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button><button type="button" class="btn btn-primary" id="photo-save">Upload</button></div></div></div>`;
+        modal.innerHTML=`<div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><h5 id="${titleId}" class="modal-title">Upload Photos</h5><button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div><div class="modal-body">${bodyHtml}</div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-label="Cancel">Cancel</button><button type="button" class="btn btn-primary" id="photo-save" aria-label="Upload photos">Upload</button></div></div></div>`;
         document.body.appendChild(modal);
         const bsModal=new bootstrap.Modal(modal);
         modal.addEventListener('hidden.bs.modal',()=>{modal.remove();resolve(null);});
@@ -344,6 +366,7 @@
           resolve(list);
         });
         bsModal.show();
+        modal.addEventListener('shown.bs.modal',()=>{modal.querySelector('select,input')?.focus();},{once:true});
       });
     }
 

--- a/public/js/tech_jobs.js
+++ b/public/js/tech_jobs.js
@@ -2,8 +2,10 @@
 (() => {
   function ready(fn){document.readyState!=='loading'?fn():document.addEventListener('DOMContentLoaded',fn);}
   function h(s){const d=document.createElement('div');d.textContent=s==null?'':String(s);return d.innerHTML;}
-  function fmtStatus(s){return (s||'').replace(/_/g,' ');}  
+  function fmtStatus(s){return (s||'').replace(/_/g,' ');}
   function truncate(str,len){str=String(str||'');return str.length>len?str.slice(0,len-1)+'\u2026':str;}
+  const timeFmt=new Intl.DateTimeFormat([], {hour:'numeric',minute:'numeric'});
+  function formatTime(str){try{const [h,m]=String(str).split(':');const d=new Date();d.setHours(Number(h),Number(m));return timeFmt.format(d);}catch(e){return str;}}
   ready(async () => {
     const list=document.getElementById('jobs-list');
     const banner=document.getElementById('date-banner');
@@ -37,7 +39,7 @@
       jobs.forEach(j => {
         const card=document.createElement('div');
         card.className='card mb-3 shadow-sm';
-        const time=j.scheduled_time?j.scheduled_time.slice(0,5):'Unscheduled';
+        const time=j.scheduled_time?formatTime(j.scheduled_time):'Unscheduled';
         const type=(j.job_skills&&j.job_skills[0]?.name)||'';
         const address=[j.customer.address_line1,j.customer.city].filter(Boolean).join(', ');
         const truncAddr=truncate(address,40);
@@ -51,9 +53,9 @@
             </div>
             <span class="badge bg-${statusColor}">${h(fmtStatus(j.status))}</span>
           </div>
-          <div class="mt-3 d-flex gap-2">
-            <a class="btn btn-outline-primary flex-fill" target="_blank" href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}">Go</a>
-            <a class="btn btn-primary flex-fill" href="tech_job.php?id=${j.job_id}">View Details</a>
+          <div class="mt-3 d-flex gap-3">
+            <a class="btn btn-outline-primary flex-fill" target="_blank" href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}" aria-label="Open directions">Go</a>
+            <a class="btn btn-primary flex-fill" href="tech_job.php?id=${j.job_id}" aria-label="View details for job ${h(j.job_id)}">View Details</a>
           </div>
         </div>`;
         list.appendChild(card);

--- a/public/tech_job.php
+++ b/public/tech_job.php
@@ -21,14 +21,18 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
   <style>
     body{padding-bottom:6rem}
     .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.75rem;z-index:1000}
+    .action-bar .d-flex{gap:1rem}
     .action-bar .btn{padding:1rem;font-size:1.25rem}
+    .btn{min-width:44px;min-height:44px}
+    .form-check-input,.form-check-label{min-width:44px;min-height:44px}
+    button:focus-visible,a:focus-visible,input[type="checkbox"]:focus-visible{outline:2px solid #0d6efd;outline-offset:2px}
     #btn-start-job.disabled{opacity:.65;pointer-events:auto}
   </style>
 </head>
 <body class="bg-light">
 <div class="container py-3">
   <div id="status-banner" class="alert alert-secondary mb-3 d-none"></div>
-  <button class="btn btn-primary mb-3 d-none" id="btn-start-job">Start Job</button>
+  <button class="btn btn-primary mb-3 d-none" id="btn-start-job" aria-label="Start job">Start Job</button>
   <div id="job-details" class="mb-4"></div>
   <div id="notes-section" class="mb-4">
     <h2 class="h6">Notes</h2>
@@ -40,11 +44,11 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
   </div>
 </div>
 <div class="action-bar">
-  <div class="d-flex gap-2">
-    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-add-note">Add Note</button>
-    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-add-photo">Add Photo</button>
-    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-checklist">Checklist</button>
-    <button class="btn btn-success flex-fill btn-lg d-none" id="btn-complete">Mark as Complete</button>
+  <div class="d-flex">
+    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-add-note" aria-label="Add note">Add Note</button>
+    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-add-photo" aria-label="Add photo">Add Photo</button>
+    <button class="btn btn-outline-secondary flex-fill btn-lg" id="btn-checklist" aria-label="Open checklist">Checklist</button>
+    <button class="btn btn-success flex-fill btn-lg d-none" id="btn-complete" aria-label="Mark job as complete">Mark as Complete</button>
   </div>
 </div>
 <script>

--- a/public/tech_jobs.php
+++ b/public/tech_jobs.php
@@ -21,12 +21,15 @@ $today = date('Y-m-d');
   <style>
     body{padding-bottom:4.5rem}
     .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.5rem}
+    .action-bar .d-flex{gap:1rem}
+    .btn,.navbar-toggler{min-width:44px;min-height:44px}
+    button:focus-visible,a:focus-visible{outline:2px solid #0d6efd;outline-offset:2px}
   </style>
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white border-bottom sticky-top">
   <div class="container-fluid align-items-center">
-    <button class="navbar-toggler" type="button" id="menu-button">
+    <button class="navbar-toggler" type="button" id="menu-button" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <span class="navbar-brand mx-auto">FieldOps</span>
@@ -40,10 +43,10 @@ $today = date('Y-m-d');
   <div id="jobs-list"></div>
 </div>
 <div class="action-bar">
-  <div class="d-flex gap-2">
-    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-note">+ Add Note</button>
-    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-photo">+ Photo</button>
-    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-map-view">MapView</button>
+  <div class="d-flex">
+    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-note" aria-label="Add note">+ Add Note</button>
+    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-photo" aria-label="Add photo">+ Photo</button>
+    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-map-view" aria-label="Map view">MapView</button>
   </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Ensure 44×44px controls, spacing, and focus outlines for tech pages
- Localize job time displays and checklist timestamps
- Add ARIA labeling and focus management for modals and buttons

## Testing
- `make lint` *(fails: Function csrf_token not found; 272 errors)*
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6367939f8832fb7e2d204c8d0b92c