### PR TITLE
Return simple checklist items

### DIFF
--- a/public/api/job_checklist.php
+++ b/public/api/job_checklist.php
@@ -29,6 +29,14 @@ if ($jobId <= 0) {
 try {
     $pdo = getPDO();
     $items = JobChecklistItem::listForJob($pdo, $jobId);
+    $items = array_map(
+        static fn(array $it): array => [
+            'id' => $it['id'],
+            'description' => $it['description'],
+            'completed' => $it['is_completed'],
+        ],
+        $items
+    );
     JsonResponse::json(['ok' => true, 'items' => $items]);
 } catch (Throwable $e) {
     JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);

--- a/public/js/tech_job.js
+++ b/public/js/tech_job.js
@@ -302,9 +302,9 @@
           div.className='form-check mb-2';
           div.setAttribute('role','listitem');
           div.innerHTML=`<input class="form-check-input" type="checkbox" id="${id}" ${it.completed?'checked':''}>
-<label class="form-check-label" for="${id}">${h(it.item||it.description||'')}</label>`;
+<label class="form-check-label" for="${id}">${h(it.description||'')}</label>`;
           const cb=div.querySelector('input');
-          cb.setAttribute('aria-label',it.item||it.description||'');
+          cb.setAttribute('aria-label',it.description||'');
           body.appendChild(div);
         });
         document.body.appendChild(modal);


### PR DESCRIPTION
## Summary
- Map job checklist API items to id, description, completed
- Read new checklist item fields on job page and render with correct label and state

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `make unit`


------
https://chatgpt.com/codex/tasks/task_e_68a658b77cac832f9fe53a0466c0fd93