### PR TITLE
feat: add bulk checklist update

### DIFF
--- a/public/api/job_checklist_update.php
+++ b/public/api/job_checklist_update.php
@@ -26,6 +26,42 @@ if (current_role() === 'guest') {
     return;
 }
 
+// New bulk update path
+$itemsRaw = $data['items'] ?? null;
+if ($itemsRaw !== null) {
+    $items = is_string($itemsRaw) ? json_decode($itemsRaw, true) : null;
+    if (!is_array($items)) {
+        JsonResponse::json(['ok' => false, 'error' => 'Invalid items', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+        return;
+    }
+    try {
+        $pdo = getPDO();
+        $pdo->beginTransaction();
+        $st = $pdo->prepare('UPDATE job_checklist_items SET is_completed = :c, completed_at = :ts WHERE id = :id');
+        foreach ($items as $it) {
+            $itemId = isset($it['id']) ? (int)$it['id'] : 0;
+            $completed = (bool)($it['completed'] ?? false);
+            if ($itemId <= 0) {
+                throw new RuntimeException('Invalid id');
+            }
+            $st->execute([
+                ':c' => $completed ? 1 : 0,
+                ':ts' => $completed ? date('Y-m-d H:i:s') : null,
+                ':id' => $itemId,
+            ]);
+        }
+        $pdo->commit();
+        JsonResponse::json(['ok' => true]);
+    } catch (Throwable $e) {
+        if (isset($pdo) && $pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+        JsonResponse::json(['ok' => false, 'error' => 'Server error', 'code' => \ErrorCodes::SERVER_ERROR], 500);
+    }
+    return;
+}
+
+// Legacy single-id toggle for backward compatibility
 $id = isset($data['id']) ? (int)$data['id'] : 0;
 if ($id <= 0) {
     JsonResponse::json(['ok' => false, 'error' => 'Missing id', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);

--- a/tests/Integration/JobChecklistUpdateTest.php
+++ b/tests/Integration/JobChecklistUpdateTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+require_once __DIR__ . '/../support/TestDataFactory.php';
+
+final class JobChecklistUpdateTest extends TestCase
+{
+    private PDO $pdo;
+    private int $jobId;
+    private int $item1;
+    private int $item2;
+
+    protected function setUp(): void
+    {
+        $this->pdo = getPDO();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec('DELETE FROM job_checklist_items');
+        $this->pdo->exec('DELETE FROM jobs');
+        $this->pdo->exec('DELETE FROM customers');
+
+        $customerId   = TestDataFactory::createCustomer($this->pdo);
+        $this->jobId  = TestDataFactory::createJob($this->pdo, $customerId, 'Checklist job', '2025-01-01', '09:00:00');
+
+        $st = $this->pdo->prepare('INSERT INTO job_checklist_items (job_id, description, is_completed) VALUES (:j,:d,0)');
+        $st->execute([':j' => $this->jobId, ':d' => 'First']);
+        $this->item1 = (int)$this->pdo->lastInsertId();
+        $st->execute([':j' => $this->jobId, ':d' => 'Second']);
+        $this->item2 = (int)$this->pdo->lastInsertId();
+    }
+
+    public function testBulkChecklistUpdate(): void
+    {
+        $payload = [
+            'items' => json_encode([
+                ['id' => $this->item1, 'completed' => true],
+                ['id' => $this->item2, 'completed' => false],
+            ]),
+        ];
+
+        $res = EndpointHarness::run(
+            __DIR__ . '/../../public/api/job_checklist_update.php',
+            $payload,
+            ['role' => 'technician']
+        );
+
+        $this->assertTrue($res['ok'] ?? false);
+
+        $row1 = $this->pdo->query('SELECT is_completed, completed_at FROM job_checklist_items WHERE id=' . $this->item1)
+            ->fetch(PDO::FETCH_ASSOC);
+        $row2 = $this->pdo->query('SELECT is_completed, completed_at FROM job_checklist_items WHERE id=' . $this->item2)
+            ->fetch(PDO::FETCH_ASSOC);
+
+        $this->assertSame(1, (int)$row1['is_completed']);
+        $this->assertNotNull($row1['completed_at']);
+        $this->assertSame(0, (int)$row2['is_completed']);
+        $this->assertNull($row2['completed_at']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow updating multiple job checklist items in a single request
- wrap bulk checklist updates in a transaction
- test coverage for bulk checklist updates

## Testing
- `vendor/bin/phpunit tests/Integration/JobChecklistUpdateTest.php` *(fails: DB connection refused)*
- `vendor/bin/phpunit tests/Integration/TechnicianJobFlowTest.php` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6599fe8a0832fab2a495904d8eddb