### PR TITLE
Require completed checklist items to finish jobs

### DIFF
--- a/public/api/job_complete.php
+++ b/public/api/job_complete.php
@@ -45,6 +45,16 @@ if ($jobId <= 0 || $technicianId <= 0 || $lat === null || $lng === null || $fina
 
 try {
     $pdo = getPDO();
+
+    $st = $pdo->prepare('SELECT COUNT(*) FROM job_checklist_items WHERE job_id = :jid AND is_completed = 0');
+    if ($st !== false) {
+        $st->execute([':jid' => $jobId]);
+        if ((int)$st->fetchColumn() > 0) {
+            JsonResponse::json(['ok' => false, 'error' => 'Checklist incomplete', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+            return;
+        }
+    }
+
     $pdo->beginTransaction();
 
     $files = [];


### PR DESCRIPTION
## Summary
- ensure job completion fails when any checklist items are incomplete
- test job completion success with completed checklist and failure when items remain

## Testing
- `./vendor/bin/phpunit tests/Integration/JobCompleteTest.php tests/Integration/TechnicianJobFlowTest.php` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a65abc884c832f932d27d15e0e1ad1