### PR TITLE
feat: allow editing checklist items on job form

### DIFF
--- a/models/JobChecklistItem.php
+++ b/models/JobChecklistItem.php
@@ -26,6 +26,16 @@ final class JobChecklistItem
     ];
 
     /**
+     * Expose default templates for job types.
+     *
+     * @return array<int, list<string>>
+     */
+    public static function defaultTemplates(): array
+    {
+        return self::DEFAULT_TEMPLATES;
+    }
+
+    /**
      * Fetch checklist items for a job.
      * @return list<array{id:int,job_id:int,description:string,is_completed:bool,completed_at:?string}>
      */

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -23,6 +23,15 @@ $customers = (new Customer($pdo))->getAll();
 $jobTypes  = $pdo->query('SELECT id, name FROM job_types ORDER BY name')->fetchAll(PDO::FETCH_ASSOC);
 $today     = date('Y-m-d');
 
+// Existing checklist items when editing
+$existingChecklist = [];
+if ($isEdit && isset($job['id'])) {
+    $existingChecklist = array_map(
+        static fn(array $item): string => $item['description'],
+        JobChecklistItem::listForJob($pdo, (int)$job['id'])
+    );
+}
+
 /** HTML escape */
 function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
 
@@ -122,6 +131,12 @@ function stickyArr(string $name, array $default = []): array {
         </div>
       </fieldset>
 
+      <fieldset class="mb-4" id="checklistFieldset" style="display:none;">
+        <legend>Checklist Items</legend>
+        <div id="checklistItems"></div>
+        <button type="button" class="btn btn-outline-secondary mt-2" id="addChecklistItem">Add Item</button>
+      </fieldset>
+
       <fieldset class="mb-4">
         <legend>Scheduling</legend>
         <div class="row g-3 align-items-end">
@@ -154,6 +169,10 @@ function stickyArr(string $name, array $default = []): array {
   <script src="/js/toast.js"></script>
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+  <script>
+    window.jobChecklistTemplates = <?= json_encode(JobChecklistItem::defaultTemplates()); ?>;
+    window.initialChecklistItems = <?= json_encode($existingChecklist); ?>;
+  </script>
   <script src="js/job_form.js"></script>
 </body>
 </html>

--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -5,6 +5,12 @@
     var mode = form.getAttribute('data-mode') || 'add';
     var errBox = document.getElementById('form-errors');
     var skillError = document.getElementById('jobSkillError');
+    var templates = window.jobChecklistTemplates || {};
+    var initItems = window.initialChecklistItems || [];
+    var checklistFieldset = document.getElementById('checklistFieldset');
+    var checklistWrap = document.getElementById('checklistItems');
+    var addBtn = document.getElementById('addChecklistItem');
+    var jobTypeSelect = document.getElementById('job_type_id');
 
     if (typeof $ !== 'undefined' && $.fn.select2) {
       var skillsSelect = $('#skills');
@@ -24,12 +30,60 @@
       else { alert(msg); }
     }
 
+    function addChecklistInput(val){
+      if(!checklistFieldset || !checklistWrap) return;
+      checklistFieldset.style.display='block';
+      var div=document.createElement('div');
+      div.className='input-group mb-2 checklist-item';
+      var inp=document.createElement('input');
+      inp.type='text';
+      inp.name='checklist_items[]';
+      inp.className='form-control checklist-input';
+      inp.required=true;
+      inp.maxLength=255;
+      inp.value=val||'';
+      var btn=document.createElement('button');
+      btn.type='button';
+      btn.className='btn btn-outline-danger';
+      btn.textContent='Remove';
+      btn.setAttribute('aria-label','Remove item');
+      btn.addEventListener('click',function(){
+        div.remove();
+        if(checklistWrap.children.length===0){ checklistFieldset.style.display='none'; }
+      });
+      div.appendChild(inp);
+      div.appendChild(btn);
+      var fb=document.createElement('div');
+      fb.className='invalid-feedback';
+      fb.textContent='Description required (max 255 characters).';
+      div.appendChild(fb);
+      checklistWrap.appendChild(div);
+    }
+
+    function renderChecklist(items){
+      if(!checklistWrap) return;
+      checklistWrap.innerHTML='';
+      (items||[]).forEach(function(it){ addChecklistInput(it); });
+      if(checklistWrap.children.length===0){ checklistFieldset.style.display='none'; }
+    }
+
+    if(addBtn){ addBtn.addEventListener('click', function(){ addChecklistInput(''); }); }
+    if(jobTypeSelect){
+      jobTypeSelect.addEventListener('change', function(){
+        var tid=jobTypeSelect.value;
+        renderChecklist(templates[tid]||[]);
+      });
+    }
+    if(initItems && initItems.length){ renderChecklist(initItems); }
+
     form.addEventListener('submit', function(e){
       e.preventDefault();
       showErrors([]);
-      var skillSelect = form.querySelector('#skills');
-      var selectedSkills = Array.from(skillSelect?.selectedOptions || []);
-      var valid = form.checkValidity();
+        var skillSelect = form.querySelector('#skills');
+        var selectedSkills = Array.from(skillSelect?.selectedOptions || []);
+        var checklistInputs=form.querySelectorAll('.checklist-input');
+        checklistInputs.forEach(function(inp){ inp.value=inp.value.trim(); });
+        var valid = form.checkValidity();
       if(selectedSkills.length===0){ if(skillError){skillError.style.display='block';} valid=false; } else { if(skillError){skillError.style.display='none';} }
       if(!valid){ form.classList.add('was-validated'); return; }
       var submitBtn=form.querySelector('button[type="submit"]');


### PR DESCRIPTION
## Summary
- show default checklist items after picking a job type and allow adding/removing before save
- persist user-defined checklist items with validation on save

## Testing
- `make unit`
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a65c3a6ffc832fbd98f41f769ac1ed