### PR TITLE
Add limits to job photo uploads

### DIFF
--- a/docs/job_photos_upload.md
+++ b/docs/job_photos_upload.md
@@ -1,0 +1,16 @@
+# Job Photo Upload Limits
+
+The `/api/job_photos_upload.php` endpoint enforces limits to protect server
+resources:
+
+- **Maximum 50 photos** per request.
+- **Maximum combined size of 20 MB** across all files.
+
+Requests exceeding these thresholds are rejected with JSON error responses:
+
+- More than 50 photos ⇒ HTTP 422 with `"error": "Too many photos (max 50)"`.
+- Total size above 20 MB ⇒ HTTP 413 with `"error": "Total upload size exceeds 20MB"`.
+
+Clients should break large uploads into smaller batches that respect these
+limits.
+

--- a/public/api/job_photos_upload.php
+++ b/public/api/job_photos_upload.php
@@ -37,6 +37,26 @@ if ($jobId <= 0 || $technicianId <= 0 || !is_array($files) || !isset($files['nam
 }
 
 $count = count($files['name']);
+$maxPhotos = 50;
+if ($count > $maxPhotos) {
+    JsonResponse::json([
+        'ok'    => false,
+        'error' => 'Too many photos (max 50)',
+        'code'  => \ErrorCodes::VALIDATION_ERROR,
+    ], 422);
+    return;
+}
+
+$maxBytes   = 20 * 1024 * 1024; // 20 MB
+$totalBytes = array_sum((array)($files['size'] ?? []));
+if ($totalBytes > $maxBytes) {
+    JsonResponse::json([
+        'ok'    => false,
+        'error' => 'Total upload size exceeds 20MB',
+        'code'  => 413,
+    ], 413);
+    return;
+}
 $allowed = ['jpg','jpeg','png','gif'];
 $uploadDir = __DIR__ . '/../uploads/jobs/';
 if (!is_dir($uploadDir)) {


### PR DESCRIPTION
## Summary
- limit job photo uploads to 50 files and 20MB total size
- document job photo upload limits for clients

## Testing
- `make lint` *(fails: Found 282 errors)*
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d3ca176c832fb6f8b41a67dfd4ac