### PR TITLE
Add checklist templates migration with default seeds

### DIFF
--- a/tests/Integration/DbSmokeTest.php
+++ b/tests/Integration/DbSmokeTest.php
@@ -17,6 +17,7 @@ final class DbSmokeTest extends TestCase
             'employees',
             'jobs',
             'job_types',
+            'checklist_templates',
             'job_employee_assignment',
             'employee_availability',
         ];

--- a/tests/migrate_test_data.php
+++ b/tests/migrate_test_data.php
@@ -68,6 +68,15 @@ $sql = [
         name VARCHAR(100) NOT NULL
     ) ENGINE=InnoDB",
 
+    "CREATE TABLE IF NOT EXISTS checklist_templates (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        job_type_id INT NOT NULL,
+        description VARCHAR(255) NOT NULL,
+        position INT DEFAULT NULL,
+        CONSTRAINT fk_cltemp_jobtype FOREIGN KEY (job_type_id) REFERENCES job_types(id)
+            ON DELETE CASCADE ON UPDATE RESTRICT
+    ) ENGINE=InnoDB",
+
     "CREATE TABLE IF NOT EXISTS job_employee_assignment (
         id INT AUTO_INCREMENT PRIMARY KEY,
         job_id INT NOT NULL,
@@ -108,6 +117,16 @@ foreach ($sql as $query) {
 
 // Seed minimal lookup data
 $pdo->exec("INSERT INTO skills (id, name) VALUES (1, 'General') ON DUPLICATE KEY UPDATE name=VALUES(name)");
-$pdo->exec("INSERT INTO job_types (id, name) VALUES (1, 'General') ON DUPLICATE KEY UPDATE name=VALUES(name)");
+$pdo->exec("INSERT INTO job_types (id, name) VALUES (1, 'Basic Installation'), (2, 'Routine Maintenance') ON DUPLICATE KEY UPDATE name=VALUES(name)");
+$pdo->exec("DELETE FROM checklist_templates");
+$pdo->exec("INSERT INTO checklist_templates (job_type_id, description, position) VALUES
+    (1, 'Review work order', 1),
+    (1, 'Confirm materials on site', 2),
+    (1, 'Perform installation', 3),
+    (1, 'Test and verify operation', 4),
+    (2, 'Inspect equipment condition', 1),
+    (2, 'Perform routine maintenance', 2),
+    (2, 'Update service log', 3)
+");
 
 echo "✅ Migration complete\n";

--- a/tests/migrations/20241004150000_create_checklist_templates.sql
+++ b/tests/migrations/20241004150000_create_checklist_templates.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS checklist_templates (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    job_type_id INT UNSIGNED NOT NULL,
+    description VARCHAR(255) NOT NULL,
+    position INT UNSIGNED NULL,
+    CONSTRAINT fk_checklist_templates_job_type FOREIGN KEY (job_type_id) REFERENCES job_types(id)
+        ON DELETE CASCADE ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO job_types (id, name) VALUES
+    (1, 'Basic Installation'),
+    (2, 'Routine Maintenance')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+
+INSERT INTO checklist_templates (job_type_id, description, position) VALUES
+    (1, 'Review work order', 1),
+    (1, 'Confirm materials on site', 2),
+    (1, 'Perform installation', 3),
+    (1, 'Test and verify operation', 4),
+    (2, 'Inspect equipment condition', 1),
+    (2, 'Perform routine maintenance', 2),
+    (2, 'Update service log', 3);


### PR DESCRIPTION
## Summary
- introduce `checklist_templates` table with job type relationship and seed default templates
- include `checklist_templates` in DB smoke tests and test data setup

## Testing
- `make lint` *(fails: Found 283 errors)*
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd7c9688832f91783f750753ba6e