### PR TITLE
Add CRUD helpers for JobTypeSkill model

### DIFF
--- a/models/JobTypeSkill.php
+++ b/models/JobTypeSkill.php
@@ -3,6 +3,32 @@
 final class JobTypeSkill
 {
     /**
+     * Fetch all skills (id and name) for a given job type.
+     *
+     * @return list<array{id:int|string,name:string}>
+     */
+    public static function allForJobType(PDO $pdo, int $jobTypeId): array
+    {
+        try {
+            $st = $pdo->prepare(
+                'SELECT s.id, s.name
+                 FROM jobtype_skills js
+                 JOIN skills s ON s.id = js.skill_id
+                 WHERE js.job_type_id = :jt
+                 ORDER BY s.name, s.id'
+            );
+            if ($st === false) {
+                return [];
+            }
+            $st->execute([':jt' => $jobTypeId]);
+            /** @var list<array{id:int|string,name:string}> $rows */
+            $rows = $st->fetchAll(PDO::FETCH_ASSOC);
+            return $rows;
+        } catch (Throwable $e) {
+            return [];
+        }
+    }
+    /**
      * List skill IDs for a given job type.
      *
      * @return list<int>
@@ -28,6 +54,22 @@ final class JobTypeSkill
      */
     public static function attach(PDO $pdo, int $jobTypeId, int $skillId): bool
     {
+        return self::create($pdo, $jobTypeId, $skillId);
+    }
+
+    /**
+     * Detach a skill from a job type.
+     */
+    public static function detach(PDO $pdo, int $jobTypeId, int $skillId): bool
+    {
+        return self::delete($pdo, $jobTypeId, $skillId);
+    }
+
+    /**
+     * Create a new job type → skill mapping.
+     */
+    public static function create(PDO $pdo, int $jobTypeId, int $skillId): bool
+    {
         try {
             $st = $pdo->prepare('INSERT INTO jobtype_skills (job_type_id, skill_id) VALUES (:jt, :sid)');
             if ($st === false) {
@@ -40,9 +82,25 @@ final class JobTypeSkill
     }
 
     /**
-     * Detach a skill from a job type.
+     * Update an existing mapping to a new skill id.
      */
-    public static function detach(PDO $pdo, int $jobTypeId, int $skillId): bool
+    public static function update(PDO $pdo, int $jobTypeId, int $skillId, int $newSkillId): bool
+    {
+        try {
+            $st = $pdo->prepare('UPDATE jobtype_skills SET skill_id = :newSid WHERE job_type_id = :jt AND skill_id = :sid');
+            if ($st === false) {
+                return false;
+            }
+            return $st->execute([':jt' => $jobTypeId, ':sid' => $skillId, ':newSid' => $newSkillId]);
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Delete a job type → skill mapping.
+     */
+    public static function delete(PDO $pdo, int $jobTypeId, int $skillId): bool
     {
         try {
             $st = $pdo->prepare('DELETE FROM jobtype_skills WHERE job_type_id = :jt AND skill_id = :sid');

--- a/tests/Unit/JobTypeSkillTest.php
+++ b/tests/Unit/JobTypeSkillTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../models/JobTypeSkill.php';
+
+final class JobTypeSkillTest extends TestCase
+{
+    private function createPdo(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE job_types (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+        $pdo->exec('CREATE TABLE skills (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)');
+        $pdo->exec('CREATE TABLE jobtype_skills (job_type_id INTEGER NOT NULL, skill_id INTEGER NOT NULL)');
+        return $pdo;
+    }
+
+    private function seed(PDO $pdo): void
+    {
+        $pdo->exec("INSERT INTO job_types (name) VALUES ('TypeA')");
+        $pdo->exec("INSERT INTO skills (name) VALUES ('Alpha'), ('Beta'), ('Gamma')");
+    }
+
+    public function testAllForJobTypeReturnsSkillDetails(): void
+    {
+        $pdo = $this->createPdo();
+        $this->seed($pdo);
+        JobTypeSkill::create($pdo, 1, 1);
+        JobTypeSkill::create($pdo, 1, 3);
+        $skills = JobTypeSkill::allForJobType($pdo, 1);
+        $this->assertSame([
+            ['id' => 1, 'name' => 'Alpha'],
+            ['id' => 3, 'name' => 'Gamma'],
+        ], $skills);
+    }
+
+    public function testCreateInsertsRow(): void
+    {
+        $pdo = $this->createPdo();
+        $this->seed($pdo);
+        $this->assertTrue(JobTypeSkill::create($pdo, 1, 1));
+        $count = (int)$pdo->query('SELECT COUNT(*) FROM jobtype_skills')->fetchColumn();
+        $this->assertSame(1, $count);
+    }
+
+    public function testUpdateChangesSkill(): void
+    {
+        $pdo = $this->createPdo();
+        $this->seed($pdo);
+        JobTypeSkill::create($pdo, 1, 1);
+        $this->assertTrue(JobTypeSkill::update($pdo, 1, 1, 2));
+        $old = (int)$pdo->query('SELECT COUNT(*) FROM jobtype_skills WHERE job_type_id = 1 AND skill_id = 1')->fetchColumn();
+        $new = (int)$pdo->query('SELECT COUNT(*) FROM jobtype_skills WHERE job_type_id = 1 AND skill_id = 2')->fetchColumn();
+        $this->assertSame(0, $old);
+        $this->assertSame(1, $new);
+    }
+
+    public function testDeleteRemovesRow(): void
+    {
+        $pdo = $this->createPdo();
+        $this->seed($pdo);
+        JobTypeSkill::create($pdo, 1, 1);
+        $this->assertTrue(JobTypeSkill::delete($pdo, 1, 1));
+        $count = (int)$pdo->query('SELECT COUNT(*) FROM jobtype_skills')->fetchColumn();
+        $this->assertSame(0, $count);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add allForJobType, create, update, delete methods to JobTypeSkill
- refactor attach/detach to use new helpers
- cover JobTypeSkill model with unit tests

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `./vendor/bin/phpunit tests/Unit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68a6e0e3381c832f8a9ff7c6b0741ff1