### PR TITLE
Add start job button and floating action menu

### DIFF
--- a/public/tech_jobs.php
+++ b/public/tech_jobs.php
@@ -19,11 +19,9 @@ $today = date('Y-m-d');
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    body{padding-bottom:4.5rem}
-    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.5rem}
-    .action-bar .d-flex{gap:1rem}
     .btn,.navbar-toggler{min-width:44px;min-height:44px}
     button:focus-visible,a:focus-visible{outline:2px solid #0d6efd;outline-offset:2px}
+    .fab{z-index:1030}
   </style>
 </head>
 <body class="bg-light">
@@ -41,13 +39,19 @@ $today = date('Y-m-d');
 </nav>
 <div id="network-banner" class="alert text-center small d-none mb-0"></div>
 <div class="container py-3">
+  <div class="mb-3">
+    <a href="/add_job.php" class="btn btn-primary w-100" id="btn-start-job">+ Start New Job</a>
+  </div>
   <div id="jobs-list"></div>
 </div>
-<div class="action-bar">
-  <div class="d-flex">
-    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-note" aria-label="Add note">+ Add Note</button>
-    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-add-photo" aria-label="Add photo">+ Photo</button>
-    <button class="btn btn-outline-secondary flex-fill py-3" id="btn-map-view" aria-label="Map view">MapView</button>
+<div class="fab position-fixed bottom-0 end-0 mb-4 me-4">
+  <div class="btn-group-vertical align-items-end">
+    <div class="collapse mb-2" id="fab-actions">
+      <button class="btn btn-light rounded-circle mb-2 shadow d-flex align-items-center justify-content-center" id="btn-add-note" aria-label="Add note" style="width:44px;height:44px;">📝</button>
+      <button class="btn btn-light rounded-circle mb-2 shadow d-flex align-items-center justify-content-center" id="btn-add-photo" aria-label="Add photo" style="width:44px;height:44px;">📷</button>
+      <button class="btn btn-light rounded-circle shadow d-flex align-items-center justify-content-center" id="btn-map-view" aria-label="Map view" style="width:44px;height:44px;">🗺️</button>
+    </div>
+    <button class="btn btn-primary rounded-circle shadow d-flex align-items-center justify-content-center" data-bs-toggle="collapse" data-bs-target="#fab-actions" aria-expanded="false" aria-label="Toggle actions" style="width:56px;height:56px;">+</button>
   </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Add Start New Job button above technician job list
- Replace bottom action bar with floating action button offering Note, Camera, and Map actions

## Testing
- `php -l public/tech_jobs.php`
- `make lint` *(fails: Function csrf_token not found and more)*
- `make test` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eb3017b0832fafa623e5f3c87521