### PR TITLE
Allow creating multiple checklist template items

### DIFF
--- a/public/admin/checklist_template_form.php
+++ b/public/admin/checklist_template_form.php
@@ -39,17 +39,50 @@ require_once __DIR__ . '/nav.php';
       <?php endforeach; ?>
     </select>
   </div>
-  <div class="mb-3">
-    <label class="form-label" for="description">Description</label>
-    <input type="text" class="form-control" id="description" name="description" required value="<?= htmlspecialchars($template['description'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+  <div id="items">
+    <?php
+    $existing = $template ? [
+        ['description' => $template['description'] ?? '', 'position' => $template['position'] ?? null],
+    ] : [['description' => '', 'position' => null]];
+    foreach ($existing as $i => $item): ?>
+      <div class="row g-2 mb-2">
+        <div class="col">
+          <label class="form-label" for="desc-<?= $i ?>">Description</label>
+          <input type="text" class="form-control" id="desc-<?= $i ?>" name="items[<?= $i ?>][description]" required value="<?= htmlspecialchars($item['description'], ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+        <div class="col-2">
+          <label class="form-label" for="pos-<?= $i ?>">Position</label>
+          <input type="number" class="form-control" id="pos-<?= $i ?>" name="items[<?= $i ?>][position]" value="<?= htmlspecialchars((string)($item['position'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+      </div>
+    <?php endforeach; ?>
   </div>
-  <div class="mb-3">
-    <label class="form-label" for="position">Position</label>
-    <input type="number" class="form-control" id="position" name="position" value="<?= htmlspecialchars($template['position'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
-  </div>
+  <?php if ($id === 0): ?>
+  <button type="button" class="btn btn-secondary mb-3" id="add-item">+ Add Item</button>
+  <?php endif; ?>
   <div class="mt-3">
     <button type="submit" class="btn btn-primary">Save</button>
     <a href="/admin/checklist_template_list.php" class="btn btn-secondary">Cancel</a>
   </div>
 </form>
+<?php if ($id === 0): ?>
+<script>
+document.getElementById('add-item').addEventListener('click', function () {
+  const container = document.getElementById('items');
+  const idx = container.children.length;
+  const row = document.createElement('div');
+  row.className = 'row g-2 mb-2';
+  row.innerHTML = `
+    <div class="col">
+      <label class="form-label" for="desc-${idx}">Description</label>
+      <input type="text" class="form-control" id="desc-${idx}" name="items[${idx}][description]" required>
+    </div>
+    <div class="col-2">
+      <label class="form-label" for="pos-${idx}">Position</label>
+      <input type="number" class="form-control" id="pos-${idx}" name="items[${idx}][position]">
+    </div>`;
+  container.appendChild(row);
+});
+</script>
+<?php endif; ?>
 <?php require_once __DIR__ . '/../../partials/footer.php'; ?>

--- a/public/admin/checklist_template_save.php
+++ b/public/admin/checklist_template_save.php
@@ -16,15 +16,32 @@ $pdo = getPDO();
 $action = $_POST['action'] ?? '';
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 $jobTypeId = isset($_POST['job_type_id']) ? (int)$_POST['job_type_id'] : 0;
+$items = [];
+if (isset($_POST['items']) && is_array($_POST['items'])) {
+    $items = $_POST['items'];
+}
 $description = trim((string)($_POST['description'] ?? ''));
 $position = isset($_POST['position']) && $_POST['position'] !== '' ? (int)$_POST['position'] : null;
 
 switch ($action) {
     case 'create':
-        if ($jobTypeId > 0 && $description !== '') { ChecklistTemplate::create($pdo, $jobTypeId, $description, $position); }
+        if ($jobTypeId > 0 && !empty($items)) {
+            foreach ($items as $it) {
+                $desc = trim((string)($it['description'] ?? ''));
+                $pos  = isset($it['position']) && $it['position'] !== '' ? (int)$it['position'] : null;
+                if ($desc !== '') {
+                    ChecklistTemplate::create($pdo, $jobTypeId, $desc, $pos);
+                }
+            }
+        } elseif ($jobTypeId > 0 && $description !== '') {
+            ChecklistTemplate::create($pdo, $jobTypeId, $description, $position);
+        }
         break;
     case 'update':
-        if ($id > 0 && $jobTypeId > 0 && $description !== '') { ChecklistTemplate::update($pdo, $id, $jobTypeId, $description, $position); }
+        $first = $items[0] ?? ['description' => $description, 'position' => $position];
+        $desc = trim((string)($first['description'] ?? ''));
+        $pos  = isset($first['position']) && $first['position'] !== '' ? (int)$first['position'] : null;
+        if ($id > 0 && $jobTypeId > 0 && $desc !== '') { ChecklistTemplate::update($pdo, $id, $jobTypeId, $desc, $pos); }
         break;
     case 'delete':
         if ($id > 0) { ChecklistTemplate::delete($pdo, $id); }

--- a/tests/Integration/ChecklistTemplateCrudTest.php
+++ b/tests/Integration/ChecklistTemplateCrudTest.php
@@ -55,4 +55,22 @@ final class ChecklistTemplateCrudTest extends TestCase
         $this->assertTrue($deleted);
         $this->assertNull(ChecklistTemplate::find($this->pdo, $id));
     }
+
+    public function testMultipleItemOrdering(): void
+    {
+        $items = [
+            ['description' => 'First', 'position' => 1],
+            ['description' => 'Second', 'position' => 2],
+            ['description' => 'Third', 'position' => 3],
+        ];
+        foreach ($items as $it) {
+            ChecklistTemplate::create($this->pdo, $this->jobTypeId, $it['description'], $it['position']);
+        }
+
+        $grouped = ChecklistTemplate::allByJobType($this->pdo);
+        $this->assertArrayHasKey($this->jobTypeId, $grouped);
+        $this->assertCount(3, $grouped[$this->jobTypeId]);
+        $descs = array_column($grouped[$this->jobTypeId], 'description');
+        $this->assertSame(['First', 'Second', 'Third'], $descs);
+    }
 }


### PR DESCRIPTION
## Summary
- Let admins add several checklist template entries at once via dynamic form controls
- Support array-based submission in checklist_template_save.php and process each item
- Cover multi-item creation ordering in ChecklistTemplateCrudTest

## Testing
- ⚠️ `vendor/bin/phpunit tests/Integration/ChecklistTemplateCrudTest.php` (database connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68a6f19f464c832f8ab5f50ffa52b94e