### PR TITLE
Clarify checklist template workflow

### DIFF
--- a/docs/checklist_template_workflow.md
+++ b/docs/checklist_template_workflow.md
@@ -1,0 +1,4 @@
+# Checklist Template Workflow
+
+Admins can define default checklist items for job types. Each form submission creates one checklist item.
+To add multiple items, save the form and return to the [Checklist Templates](../public/admin/checklist_template_list.php) page to add more entries.

--- a/public/admin/checklist_template_form.php
+++ b/public/admin/checklist_template_form.php
@@ -31,6 +31,10 @@ require_once __DIR__ . '/nav.php';
   <?php else: ?>
     <input type="hidden" name="action" value="create">
   <?php endif; ?>
+  <div class="alert alert-info small" role="alert">
+    Each submission creates a single checklist item. To add multiple items, save and return to the
+    <a href="/admin/checklist_template_list.php" class="alert-link">Checklist Templates</a> page to add more.
+  </div>
   <div class="mb-3">
     <label class="form-label" for="job_type_id">Job Type</label>
     <select class="form-select" id="job_type_id" name="job_type_id" required>


### PR DESCRIPTION
## Summary
- Add notice to checklist template form explaining each submission creates a single item and link to the template list
- Document checklist template workflow for admins

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f308c514832fad209aad09ddda86