### PR TITLE
Add reusable CSS utilities and replace inline styles

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -5,3 +5,80 @@
     font-weight: 600;
 }
 
+/* Accessible touch target size */
+.touch-target {
+    min-width: 44px;
+    min-height: 44px;
+}
+
+/* Consistent focus outline */
+.focus-ring:focus-visible {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
+}
+
+/* Colorblind-safe status palette (Okabe–Ito) */
+.status-success {
+    color: #fff;
+    background-color: #009e73;
+}
+
+.status-warning {
+    color: #000;
+    background-color: #e69f00;
+}
+
+.status-danger {
+    color: #fff;
+    background-color: #d55e00;
+}
+
+.status-info {
+    color: #000;
+    background-color: #56b4e9;
+}
+
+/* Floating action button positioning */
+.fab {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 1030;
+}
+
+/* Sticky bottom bar positioning */
+.sticky-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border-top: 1px solid #dee2e6;
+    padding: 0.75rem;
+    z-index: 1000;
+}
+
+.sticky-bar .btn {
+    padding: 1rem;
+    font-size: 1.25rem;
+}
+
+.sticky-bar .d-flex {
+    gap: 1rem;
+}
+
+/* Space for sticky bar at page bottom */
+.has-sticky-bar {
+    padding-bottom: 6rem;
+}
+
+/* Photo preview sizing */
+.photo-preview img {
+    max-width: 120px;
+}
+
+#btn-start-job.disabled {
+    opacity: 0.65;
+    pointer-events: auto;
+}
+

--- a/public/tech_job.php
+++ b/public/tech_job.php
@@ -18,27 +18,18 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
   <title>Job Details</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    body{padding-bottom:6rem}
-    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.75rem;z-index:1000}
-    .action-bar .d-flex{gap:1rem}
-    .action-bar .btn{padding:1rem;font-size:1.25rem}
-    .btn{min-width:44px;min-height:44px}
-    .form-check-input,.form-check-label{min-width:44px;min-height:44px}
-    button:focus-visible,a:focus-visible,input[type="checkbox"]:focus-visible{outline:2px solid #0d6efd;outline-offset:2px}
-    #btn-start-job.disabled{opacity:.65;pointer-events:auto}
-  </style>
+  <link href="/css/app.css" rel="stylesheet">
 </head>
-<body class="bg-light">
+<body class="bg-light has-sticky-bar">
 <div class="container py-3">
   <div id="network-banner" class="alert text-center small d-none"></div>
   <header id="job-header" class="mb-3"></header>
   <section id="customer-info" class="mb-4"></section>
-  <button class="btn btn-primary mb-3 d-none" id="btn-start-job" aria-label="Start job">Start Job</button>
+  <button class="btn btn-primary mb-3 d-none touch-target focus-ring" id="btn-start-job" aria-label="Start job">Start Job</button>
   <section id="timer-section" class="mb-4">
     <div class="d-flex justify-content-between align-items-center">
       <div id="job-timer" class="fw-bold">00:00:00</div>
-      <button class="btn btn-link p-0" id="checklist-toggle" data-bs-toggle="collapse" data-bs-target="#checklist-collapse" aria-expanded="false" aria-controls="checklist-collapse">Checklist</button>
+      <button class="btn btn-link p-0 touch-target focus-ring" id="checklist-toggle" data-bs-toggle="collapse" data-bs-target="#checklist-collapse" aria-expanded="false" aria-controls="checklist-collapse">Checklist</button>
     </div>
     <div class="collapse" id="checklist-collapse">
       <div class="progress mb-2">
@@ -56,13 +47,13 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     <div id="job-photos" class="d-flex flex-wrap gap-2"></div>
   </section>
 </div>
-<nav class="action-bar">
+<nav class="sticky-bar">
   <div class="d-flex justify-content-around">
-    <button class="btn btn-outline-secondary flex-fill" id="menu-checklist" aria-label="Toggle checklist">Checklist</button>
-    <button class="btn btn-outline-secondary flex-fill" id="menu-note" aria-label="Add note">Note</button>
-    <button class="btn btn-outline-secondary flex-fill" id="menu-camera" aria-label="Add photo">Camera</button>
-    <a class="btn btn-outline-secondary flex-fill" id="menu-map" target="_blank" rel="noopener" aria-label="Open map">Map</a>
-    <button class="btn btn-success flex-fill d-none" id="btn-complete" aria-label="Mark job as complete">Complete</button>
+    <button class="btn btn-outline-secondary flex-fill touch-target focus-ring" id="menu-checklist" aria-label="Toggle checklist">Checklist</button>
+    <button class="btn btn-outline-secondary flex-fill touch-target focus-ring" id="menu-note" aria-label="Add note">Note</button>
+    <button class="btn btn-outline-secondary flex-fill touch-target focus-ring" id="menu-camera" aria-label="Add photo">Camera</button>
+    <a class="btn btn-outline-secondary flex-fill touch-target focus-ring" id="menu-map" target="_blank" rel="noopener" aria-label="Open map">Map</a>
+    <button class="btn btn-success flex-fill d-none touch-target focus-ring" id="btn-complete" aria-label="Mark job as complete">Complete</button>
   </div>
 </nav>
 <script>

--- a/public/tech_job_complete.php
+++ b/public/tech_job_complete.php
@@ -18,22 +18,16 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
   <title>Complete Job</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    body{padding-bottom:6rem}
-    .action-bar{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #dee2e6;padding:.75rem;z-index:1000}
-    .action-bar .btn{padding:1rem;font-size:1.25rem}
-    #sig-canvas{border:1px solid #ced4da;border-radius:.25rem}
-    .photo-preview img{max-width:120px}
-  </style>
+  <link href="/css/app.css" rel="stylesheet">
 </head>
-<body class="bg-light">
+<body class="bg-light has-sticky-bar">
 <div class="container py-3">
   <div id="network-banner" class="alert text-center small d-none"></div>
   <div class="mb-3">
     <label for="final-note" class="form-label">Summary Note</label>
     <div class="input-group">
       <textarea class="form-control" id="final-note" rows="4"></textarea>
-      <button class="btn btn-outline-secondary" id="btn-voice-note" type="button" aria-label="Voice input">🎤</button>
+      <button class="btn btn-outline-secondary touch-target focus-ring" id="btn-voice-note" type="button" aria-label="Voice input">🎤</button>
     </div>
     <div class="invalid-feedback"></div>
   </div>
@@ -41,7 +35,7 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     <label class="form-label d-block">Final Photos</label>
     <small class="text-muted d-block mb-1">Tap "Add Photos" to include required images.</small>
     <div id="photo-list" class="d-flex flex-column gap-2"></div>
-    <button class="btn btn-outline-primary btn-lg mt-2" id="btn-add-photo" type="button">Add Photos</button>
+    <button class="btn btn-outline-primary btn-lg mt-2 touch-target focus-ring" id="btn-add-photo" type="button">Add Photos</button>
     <div class="invalid-feedback" id="photo-feedback"></div>
     <input type="file" id="photo-input" accept="image/*" multiple hidden>
   </div>
@@ -49,12 +43,12 @@ $jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
     <label class="form-label d-block">Customer Signature</label>
     <small class="text-muted d-block mb-1">Customer must sign in the box below.</small>
     <canvas id="sig-canvas" width="300" height="200" class="w-100 border border-2 rounded"></canvas>
-    <button class="btn btn-sm btn-outline-secondary mt-2" id="btn-clear-sig" type="button">Clear</button>
+    <button class="btn btn-sm btn-outline-secondary mt-2 touch-target focus-ring" id="btn-clear-sig" type="button">Clear</button>
     <div class="invalid-feedback" id="sig-feedback"></div>
   </div>
 </div>
-<div class="action-bar">
-  <button class="btn btn-success w-100" id="btn-submit" type="button">Submit Completion</button>
+<div class="sticky-bar">
+  <button class="btn btn-success w-100 touch-target focus-ring" id="btn-submit" type="button">Submit Completion</button>
 </div>
 <script>
   window.CSRF_TOKEN = "<?=htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8')?>";

--- a/public/tech_jobs.php
+++ b/public/tech_jobs.php
@@ -18,16 +18,12 @@ $today = date('Y-m-d');
   <title>Today's Jobs</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <style>
-    .btn,.navbar-toggler{min-width:44px;min-height:44px}
-    button:focus-visible,a:focus-visible{outline:2px solid #0d6efd;outline-offset:2px}
-    .fab{z-index:1030}
-  </style>
+  <link href="/css/app.css" rel="stylesheet">
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-light bg-white border-bottom sticky-top">
   <div class="container-fluid align-items-center">
-    <button class="navbar-toggler" type="button" id="menu-button" aria-label="Toggle navigation">
+    <button class="navbar-toggler touch-target focus-ring" type="button" id="menu-button" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <span class="navbar-brand mx-auto">FieldOps</span>
@@ -40,7 +36,7 @@ $today = date('Y-m-d');
 <div id="network-banner" class="alert text-center small d-none mb-0"></div>
 <div class="container py-3">
   <div class="mb-3">
-    <a href="/add_job.php" class="btn btn-primary w-100" id="btn-start-job">+ Start New Job</a>
+    <a href="/add_job.php" class="btn btn-primary w-100 touch-target focus-ring" id="btn-start-job">+ Start New Job</a>
   </div>
   <div id="jobs-list"></div>
 </div>


### PR DESCRIPTION
## Summary
- add touch-target, focus-ring, status palette, fab and sticky-bar utilities in app.css
- link app.css and swap inline styles for utility classes in technician job pages
- ensure job start button preserves disabled styling

## Testing
- `php -l public/tech_jobs.php`
- `php -l public/tech_job.php`
- `php -l public/tech_job_complete.php`
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f8479284832fab140f977c5a5ea3