### PR TITLE
Allow more time formats for job save

### DIFF
--- a/public/job_save.php
+++ b/public/job_save.php
@@ -22,7 +22,16 @@ function log_error(string $msg): void {
  * Attempt to normalize various time formats to HH:MM.
  */
 function normalize_time(string $time): ?string {
-  $formats = ['H:i', 'H:i:s', 'g:i A', 'g:i a', 'h:i A', 'h:i a'];
+  // Accepted input formats including 24h and 12h variants, with or without
+  // seconds and with optional leading zeros.
+  $formats = [
+    'H:i',    'H:i:s',    // 24h with leading zero
+    'G:i',    'G:i:s',    // 24h without leading zero
+    'g:i A',  'g:i a',    // 12h no leading zero, AM/PM
+    'h:i A',  'h:i a',    // 12h with leading zero, AM/PM
+    'g:i:s A','g:i:s a',  // 12h with seconds
+    'h:i:s A','h:i:s a',  // 12h with seconds and leading zero
+  ];
   foreach ($formats as $fmt) {
     $dt = DateTime::createFromFormat($fmt, $time);
     $errs = DateTime::getLastErrors() ?: ['warning_count' => 0, 'error_count' => 0];

--- a/tests/Integration/JobWriteValidationTest.php
+++ b/tests/Integration/JobWriteValidationTest.php
@@ -64,4 +64,20 @@ final class JobWriteValidationTest extends TestCase
         ], ['role' => 'dispatcher']);
         $this->assertTrue($withAmPm['ok'] ?? false, 'AM/PM time rejected');
     }
+
+    public function testTwentyFourHourTimeWithoutLeadingZeroIsAccepted(): void
+    {
+        $customerId = (int)$this->pdo->query("SELECT id FROM customers LIMIT 1")->fetchColumn();
+
+        $withoutLeadingZero = EndpointHarness::run(__DIR__ . '/../../public/job_save.php', [
+            'customer_id'    => $customerId,
+            'description'    => 'Job with 24h time no leading zero',
+            'scheduled_date' => '2025-08-25',
+            'scheduled_time' => '9:05',
+            'status'         => 'scheduled',
+            'skills'         => [1],
+        ], ['role' => 'dispatcher']);
+
+        $this->assertTrue($withoutLeadingZero['ok'] ?? false, '24h time without leading zero rejected');
+    }
 }


### PR DESCRIPTION
## Summary
- broaden accepted time formats in job_save endpoint
- test 24h times without leading zero

## Testing
- `vendor/bin/phpunit tests/Integration/JobWriteValidationTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e989d00832fb0989396659c64ab