### PR TITLE
Allow more time formats for job save

### DIFF
--- a/public/job_save.php
+++ b/public/job_save.php
@@ -18,11 +18,33 @@ function log_error(string $msg): void {
   error_log(date('[Y-m-d H:i:s] ').$msg.PHP_EOL, 3, __DIR__ . '/../logs/job_errors.log');
 }
 
+// Log fatal errors that might bypass normal exception handling.
+register_shutdown_function(static function (): void {
+  $err = error_get_last();
+  if ($err && in_array($err['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+    log_error('Fatal error: ' . $err['message'] . ' in ' . $err['file'] . ':' . $err['line']);
+  }
+});
+
+// Capture incoming request payload for debugging purposes.
+if (!empty($_POST)) {
+  log_error('Request payload: ' . json_encode($_POST, JSON_UNESCAPED_SLASHES));
+}
+
 /**
  * Attempt to normalize various time formats to HH:MM.
  */
 function normalize_time(string $time): ?string {
-  $formats = ['H:i', 'H:i:s', 'g:i A', 'g:i a', 'h:i A', 'h:i a'];
+  // Accepted input formats including 24h and 12h variants, with or without
+  // seconds and with optional leading zeros.
+  $formats = [
+    'H:i',    'H:i:s',    // 24h with leading zero
+    'G:i',    'G:i:s',    // 24h without leading zero
+    'g:i A',  'g:i a',    // 12h no leading zero, AM/PM
+    'h:i A',  'h:i a',    // 12h with leading zero, AM/PM
+    'g:i:s A','g:i:s a',  // 12h with seconds
+    'h:i:s A','h:i:s a',  // 12h with seconds and leading zero
+  ];
   foreach ($formats as $fmt) {
     $dt = DateTime::createFromFormat($fmt, $time);
     $errs = DateTime::getLastErrors() ?: ['warning_count' => 0, 'error_count' => 0];
@@ -189,6 +211,9 @@ try {
 
 } catch (Throwable $e) {
   if (isset($pdo) && $pdo->inTransaction()) { $pdo->rollBack(); }
-  log_error('Exception: '.$e->getMessage());
+  $detail = 'Exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
+           . PHP_EOL . $e->getTraceAsString()
+           . PHP_EOL . 'POST: ' . json_encode($_POST, JSON_UNESCAPED_SLASHES);
+  log_error($detail);
   json_out(['ok'=>false,'error'=>'Server error','code'=>500,'detail'=>$e->getMessage()], 500);
 }

--- a/tests/Integration/JobWriteValidationTest.php
+++ b/tests/Integration/JobWriteValidationTest.php
@@ -64,4 +64,20 @@ final class JobWriteValidationTest extends TestCase
         ], ['role' => 'dispatcher']);
         $this->assertTrue($withAmPm['ok'] ?? false, 'AM/PM time rejected');
     }
+
+    public function testTwentyFourHourTimeWithoutLeadingZeroIsAccepted(): void
+    {
+        $customerId = (int)$this->pdo->query("SELECT id FROM customers LIMIT 1")->fetchColumn();
+
+        $withoutLeadingZero = EndpointHarness::run(__DIR__ . '/../../public/job_save.php', [
+            'customer_id'    => $customerId,
+            'description'    => 'Job with 24h time no leading zero',
+            'scheduled_date' => '2025-08-25',
+            'scheduled_time' => '9:05',
+            'status'         => 'scheduled',
+            'skills'         => [1],
+        ], ['role' => 'dispatcher']);
+
+        $this->assertTrue($withoutLeadingZero['ok'] ?? false, '24h time without leading zero rejected');
+    }
 }


### PR DESCRIPTION
## Summary
- broaden accepted time formats in job_save endpoint
- test 24h times without leading zero
- log request details and fatal errors for job_save

## Testing
- `vendor/bin/phpunit tests/Integration/JobWriteValidationTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e989d00832fb0989396659c64ab