### PR TITLE
Handle job type changes for checklist templates

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -102,10 +102,18 @@
     }
     if(jobTypeSelect){
       jobTypeSelect.addEventListener('change', function(){
-        var selected=Array.from(jobTypeSelect.selectedOptions||[]).map(function(o){return o.value;});
-        var tid=selected.length?selected[0]:'';
-        checklistItems=(templates[tid]||[]).slice();
+        var selectedIds = Array.from(jobTypeSelect.selectedOptions||[]).map(function(o){ return o.value; });
+        checklistItems = [];
+        selectedIds.forEach(function(tid){
+          if(Array.isArray(templates[tid])){
+            checklistItems = checklistItems.concat(templates[tid]);
+          }
+        });
+        renderChecklist(checklistItems);
         updateHiddenInputs();
+        if(checklistModal && checklistModalEl && checklistModalEl.classList.contains('show')){
+          checklistModal.show();
+        }
       });
     }
     updateHiddenInputs();


### PR DESCRIPTION
## Summary
- Combine checklist templates for all selected job types
- Refresh modal checklist contents when job type selection changes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a77668c2c4832fbe0a265aa2648d4a