### PR TITLE
Auto-trigger job type change for preselected jobs

### DIFF
--- a/public/add_job.php
+++ b/public/add_job.php
@@ -29,8 +29,24 @@ register_shutdown_function(static function (): void {
 });
 
 try {
+    ob_start();
     require __DIR__ . '/job_form.php';
+    $output = ob_get_clean();
+    $autoScript = <<<HTML
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    var jobTypeSelect = document.getElementById('job_type_ids');
+    if (jobTypeSelect && jobTypeSelect.selectedOptions.length) {
+        jobTypeSelect.dispatchEvent(new Event('change'));
+    }
+});
+</script>
+HTML;
+    echo str_replace('</body>', $autoScript . "\n</body>", $output);
 } catch (Throwable $e) {
+    if (ob_get_level() > 0) {
+        ob_end_clean();
+    }
     log_error(
         'Exception: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine()
         . PHP_EOL . $e->getTraceAsString()


### PR DESCRIPTION
## Summary
- Inject inline script in add_job.php to trigger job type change handler on page load when job types are preselected, ensuring checklist modal items are initialized.

## Testing
- `php -l public/add_job.php`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a777aba210832f90ea682781bea1ab