### PR TITLE
Refresh checklist for selected job types

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -102,7 +102,7 @@
     }
     if(jobTypeSelect){
       jobTypeSelect.addEventListener('change', function(){
-        var selectedIds = Array.from(jobTypeSelect.selectedOptions||[]).map(function(o){ return o.value; });
+        var selectedIds = Array.from(jobTypeSelect.selectedOptions || []).map(function(o){ return o.value; });
         checklistItems = [];
         selectedIds.forEach(function(tid){
           if(Array.isArray(templates[tid])){
@@ -111,9 +111,6 @@
         });
         renderChecklist(checklistItems);
         updateHiddenInputs();
-        if(checklistModal && checklistModalEl && checklistModalEl.classList.contains('show')){
-          checklistModal.show();
-        }
       });
     }
     updateHiddenInputs();


### PR DESCRIPTION
## Summary
- Merge checklists from all selected job types and refresh modal content without auto-opening it.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make lint` *(fails: Found 290 errors)*
- `make test` *(fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a7957d9200832f9c48efbbb489378a