### PR TITLE
feat: include job type templates on options

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -5,7 +5,6 @@
     var mode = form.getAttribute('data-mode') || 'add';
     var errBox = document.getElementById('form-errors');
     var skillError = document.getElementById('jobSkillError');
-    var templates = window.jobChecklistTemplates || {};
     var initItems = window.initialChecklistItems || [];
     var checklistLink = document.getElementById('checklistModalLink');
     var checklistModalEl = document.getElementById('checklistModal');
@@ -102,11 +101,16 @@
     }
     if(jobTypeSelect){
       jobTypeSelect.addEventListener('change', function(){
-        var selectedIds = Array.from(jobTypeSelect.selectedOptions||[]).map(function(o){ return o.value; });
         checklistItems = [];
-        selectedIds.forEach(function(tid){
-          if(Array.isArray(templates[tid])){
-            checklistItems = checklistItems.concat(templates[tid]);
+        Array.from(jobTypeSelect.selectedOptions || []).forEach(function(o){
+          var tpl = o.getAttribute('data-template');
+          if(tpl){
+            try{
+              var arr = JSON.parse(tpl);
+              if(Array.isArray(arr)){
+                checklistItems = checklistItems.concat(arr);
+              }
+            }catch(e){/* ignore parse errors */}
           }
         });
         renderChecklist(checklistItems);


### PR DESCRIPTION
## Summary
- embed job type checklist templates in job type `<option>` tags
- build checklist items from selected option templates

## Testing
- `make lint` *(fails: Function csrf_token not found; Cannot call method fetchColumn() on PDOStatement|false)*
- `make test` *(fails: DB connection failed: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bbe9bc34832fbf4692385fb95723