### PR TITLE
Ensure checklist link is always clickable in job form

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -72,21 +72,19 @@
     function renderChecklist(items){
       if(!modalBody) return;
       modalBody.innerHTML='';
+
+      if(checklistLink){
+        checklistLink.classList.remove('disabled');
+        checklistLink.removeAttribute('aria-disabled');
+      }
+
       var arr = items || [];
       if(!arr.length){
         var p=document.createElement('p');
         p.className='text-muted';
         p.textContent='No default checklist for this job type.';
         modalBody.appendChild(p);
-        if(checklistLink){
-          checklistLink.classList.add('disabled');
-          checklistLink.setAttribute('aria-disabled','true');
-        }
         return;
-      }
-      if(checklistLink){
-        checklistLink.classList.remove('disabled');
-        checklistLink.removeAttribute('aria-disabled');
       }
       arr.forEach(function(it){ addChecklistInput(it); });
     }


### PR DESCRIPTION
## Summary
- Keep job form's checklist link enabled even when no default items exist
- Simplify renderChecklist to show placeholder text without disabling link

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `make unit`


------
https://chatgpt.com/codex/tasks/task_e_68a7c3828f88832f92a13fbaa86ea73c