### PR TITLE
Improve job form template parsing debug output

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -124,14 +124,16 @@
       jobTypeSelect.addEventListener('change', function(){
         checklistItems = [];
         Array.from(jobTypeSelect.selectedOptions || []).forEach(function(o){
-          var tpl = o.getAttribute('data-template');
-          if(tpl){
-            try{
+          var tpl = o.dataset.template;
+          if (tpl) {
+            try {
               var arr = JSON.parse(tpl);
-              if(Array.isArray(arr)){
+              if (Array.isArray(arr)) {
                 checklistItems = checklistItems.concat(arr);
               }
-            }catch(e){/* ignore parse errors */}
+            } catch (e) {
+              console.error('Failed to parse checklist template JSON:', e);
+            }
           }
         });
         renderChecklist(checklistItems);


### PR DESCRIPTION
## Summary
- Use dataset API to read template attribute in job form change handler
- Log JSON parsing errors for job template debugging

## Testing
- `npm test` (fails: Could not read package.json)
- `make test` (fails: SQLSTATE[HY000] [2002] Connection refused)
- `make unit`
- `make lint` (fails: Function csrf_token not found; 292 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a84da77928832fa1f94d608a0b82bb