### PR TITLE
Normalize debug job status handling and add tests

### DIFF
--- a/public/dev_job_save_debug.php
+++ b/public/dev_job_save_debug.php
@@ -40,12 +40,12 @@ $scheduledTime   = trim((string)($_POST['scheduled_time'] ?? ''));
 $durationMinutes = isset($_POST['duration_minutes']) ? (int)$_POST['duration_minutes'] : 0;
 $statusIn        = trim((string)($_POST['status'] ?? ''));
 
-$allowedStatuses = [
-  'draft','scheduled','assigned','in_progress','completed','closed','cancelled',
-  'unassigned','Unassigned','Draft','Scheduled','Assigned','In Progress','Completed','Closed','Cancelled'
-];
-$status = $statusIn !== '' ? $statusIn : 'Unassigned';
-if (!in_array($status, $allowedStatuses, true)) { $status = 'Unassigned'; }
+require_once __DIR__ . '/../models/Job.php';
+$allowedStatuses = Job::allowedStatuses();
+$status = $statusIn !== ''
+    ? strtolower(str_replace(' ', '_', $statusIn))
+    : 'draft';
+if (!in_array($status, $allowedStatuses, true)) { $status = 'draft'; }
 
 $errors = [];
 if ($customerId <= 0)      { $errors[] = 'customer_id required'; }

--- a/tests/Integration/JobStatusNormalizationTest.php
+++ b/tests/Integration/JobStatusNormalizationTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+
+final class JobStatusNormalizationTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = getPDO();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('DELETE FROM jobs');
+        $this->pdo->exec('DELETE FROM customers');
+        $this->pdo->exec("INSERT INTO customers (first_name,last_name,phone,created_at) VALUES ('Val','Customer','555-1111',NOW())");
+    }
+
+    /**
+     * @dataProvider provideStatuses
+     */
+    public function testStatusStoredLowercase(string $input, string $expected): void
+    {
+        $customerId = (int)$this->pdo->query('SELECT id FROM customers LIMIT 1')->fetchColumn();
+        $res = EndpointHarness::run(
+            __DIR__ . '/../../public/dev_job_save_debug.php',
+            [
+                'customer_id'    => $customerId,
+                'description'    => 'Case test',
+                'scheduled_date' => '2025-09-01',
+                'scheduled_time' => '10:00',
+                'duration_minutes' => 30,
+                'status'         => $input,
+            ],
+            ['role' => 'dispatcher']
+        );
+
+        $this->assertTrue($res['ok'] ?? false, 'Endpoint failed: ' . ($res['error'] ?? 'unknown'));
+        $this->assertSame($expected, $res['status'] ?? null);
+
+        $id = (int)($res['id'] ?? 0);
+        $dbStatus = $this->pdo->query("SELECT status FROM jobs WHERE id = $id")->fetchColumn();
+        $this->assertSame($expected, $dbStatus);
+    }
+
+    public static function provideStatuses(): array
+    {
+        return [
+            ['Scheduled', 'scheduled'],
+            ['In Progress', 'in_progress'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize incoming job status to lowercase using canonical list in the debug job save endpoint
- Add integration test to ensure mixed-case job statuses are stored lowercase

## Testing
- `vendor/bin/phpunit tests/Integration/JobStatusNormalizationTest.php` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d1f7ed8c832f9801574fdbef0714