### PR TITLE
Add job type checklist debug logs

### DIFF
--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -80,7 +80,8 @@
       }
 
       var arr = items || [];
-      if(!arr.length){
+      if (!arr.length) {
+        console.warn('No checklist templates found for selected job types.');
         var p=document.createElement('p');
         p.className='text-muted';
         p.textContent='No default checklist for this job type.';
@@ -113,6 +114,7 @@
           try{
             var arr = JSON.parse(tpl);
             if(Array.isArray(arr)){
+              console.debug('Templates for job type', o.value, arr);
               checklistItems = checklistItems.concat(arr);
             }
           }catch(e){/* ignore parse errors */}
@@ -147,6 +149,7 @@
             try {
               var arr = JSON.parse(tpl);
               if (Array.isArray(arr)) {
+                console.debug('Templates for job type', o.value, arr);
                 checklistItems = checklistItems.concat(arr);
               }
             } catch (e) {


### PR DESCRIPTION
## Summary
- log warning when no checklist templates exist for chosen job types
- add debug output of checklist templates for each selected job type

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a850739588832f9951b11c835c8275