### PR TITLE
Prevent premature submission when selecting Google addresses

### DIFF
--- a/public/js/google_address_autocomplete.js
+++ b/public/js/google_address_autocomplete.js
@@ -14,6 +14,16 @@ function initializeAddressAutocomplete(inputId, fieldMap = {}) {
         fields: ['address_components', 'geometry', 'place_id']
     });
 
+    // Prevent the form from submitting when selecting an address via Enter.
+    // Without this, pressing Enter can submit the form before the Google
+    // "place_changed" event populates the individual address fields, leaving
+    // the full address string in the first line input.
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+        }
+    });
+
     autocomplete.addListener('place_changed', function () {
         const place = autocomplete.getPlace();
 


### PR DESCRIPTION
## Summary
- stop form submission when Enter is pressed in the address field so Google autocomplete can fill individual fields

## Testing
- `vendor/bin/phpstan analyse --memory-limit=1G` *(errors: Function csrf_token not found, etc.)*
- `vendor/bin/phpunit tests/Unit --testdox`
- `vendor/bin/phpunit tests/Integration --testdox` *(fail: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a87d697c34832fa0fb5fba38399fc3