### PR TITLE
Link job list entries to edit forms with return URLs

### DIFF
--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -64,7 +64,7 @@
         const custCell=document.createElement('td');
         const name=h(job.customer.first_name)+' '+h(job.customer.last_name);
         const addr=h(job.customer.address_line1||'');
-        custCell.innerHTML=`<a href="customer_form.php?id=${job.customer.id}" target="_blank">${name}</a><br><small class="text-muted">${addr}</small>`;
+        custCell.innerHTML=`<a href="edit_customer.php?id=${job.customer.id}&return=${encodeURIComponent(window.location.href)}" target="_blank">${name}</a><br><small class="text-muted">${addr}</small>`;
         tr.appendChild(custCell);
         // Job skills
         const jsCell=document.createElement('td');
@@ -82,7 +82,7 @@
         // Employees
         const empCell=document.createElement('td');
         if(job.assigned_employees?.length){
-          const names=job.assigned_employees.map(e=>`<a href="employee_form.php?id=${e.id}" target="_blank">${h(e.first_name)} ${h(e.last_name)}</a>`);
+            const names=job.assigned_employees.map(e=>`<a href="edit_employee.php?id=${e.id}&return=${encodeURIComponent(window.location.href)}" target="_blank">${h(e.first_name)} ${h(e.last_name)}</a>`);
           let html=names.slice(0,2).join(', ');
           if(names.length>2) html+=` <span class="text-muted">+${names.length-2} more</span>`;
           empCell.innerHTML=html;


### PR DESCRIPTION
## Summary
- use `edit_customer.php` and `edit_employee.php` from jobs list
- append current page URL via `return` query param so edit forms can go back

## Testing
- `make unit`
- `make integration` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a885dda8a0832f895967c301b503c6