### PR TITLE
Fix search query placeholder mismatch in assignments table

### DIFF
--- a/public/assignments_table.php
+++ b/public/assignments_table.php
@@ -48,11 +48,14 @@ if ($status !== '') {
 
 if ($search !== '') {
   $sql .= " AND (
-      j.description LIKE :q OR
-      c.first_name LIKE :q OR
-      c.last_name  LIKE :q
+      j.description LIKE :q1 OR
+      c.first_name LIKE :q2 OR
+      c.last_name  LIKE :q3
   )";
-  $params[':q'] = '%' . $search . '%';
+  $wild = '%' . $search . '%';
+  $params[':q1'] = $wild;
+  $params[':q2'] = $wild;
+  $params[':q3'] = $wild;
 }
 
 $sql .= "


### PR DESCRIPTION
## Summary
- avoid PDO parameter collision in assignments search by using unique placeholders

## Testing
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8852061a8832f8130f6ebbef1c230