### PR TITLE
Support custom return redirects in employee forms

### DIFF
--- a/public/employee_form.php
+++ b/public/employee_form.php
@@ -26,6 +26,14 @@ $skills = Skill::all($pdo);
 /** @var list<array{id:int|string,name:string}> $roles */
 $roles = Role::all($pdo);
 
+$returnUrl = '';
+if (isset($_GET['return'])) {
+    $returnUrl = filter_var((string)$_GET['return'], FILTER_SANITIZE_URL);
+    if ($returnUrl !== '' && (parse_url($returnUrl, PHP_URL_SCHEME) !== null || parse_url($returnUrl, PHP_URL_HOST) !== null)) {
+        $returnUrl = '';
+    }
+}
+
 /** HTML escape */
 function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
 
@@ -62,8 +70,9 @@ function stickyArr(string $name, array $default = []): array {
       <p>Employee not found.</p>
     <?php else: ?>
     <div id="form-errors" class="text-danger mb-3"></div>
-    <form id="employeeForm" method="post" action="employee_save.php" autocomplete="off" class="needs-validation" novalidate data-mode="<?= $isEdit ? 'edit' : 'add' ?>">
+    <form id="employeeForm" method="post" action="employee_save.php" autocomplete="off" class="needs-validation" novalidate data-mode="<?= $isEdit ? 'edit' : 'add' ?>" data-return="<?= s($returnUrl) ?>">
       <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
+      <input type="hidden" name="return" value="<?= s($returnUrl) ?>">
       <?php if ($isEdit): ?>
         <input type="hidden" name="id" value="<?= s((string)($employee['id'] ?? '')) ?>">
       <?php endif; ?>
@@ -181,7 +190,8 @@ function stickyArr(string $name, array $default = []): array {
 
       <div class="mt-3">
         <button type="submit" class="btn btn-primary"><?= $isEdit ? 'Save Changes' : 'Save Employee' ?></button>
-        <button type="button" class="btn btn-secondary" onclick="window.location.href='employees.php'">Cancel</button>
+        <?php $cancel = $returnUrl !== '' ? $returnUrl : 'employees.php'; ?>
+        <button type="button" class="btn btn-secondary" onclick="window.location.href='<?= s($cancel) ?>'">Cancel</button>
       </div>
     </form>
     <?php endif; ?>

--- a/public/employee_save.php
+++ b/public/employee_save.php
@@ -82,6 +82,13 @@ $hireDate       = trim((string)($_POST['hire_date']         ?? ''));
 $status         = trim((string)($_POST['status']            ?? ''));
 $roleId         = (string)($_POST['role_id'] ?? '') !== '' ? (int)$_POST['role_id'] : null;
 $skills         = $_POST['skills'] ?? [];
+$return         = '';
+if (isset($_POST['return'])) {
+    $return = filter_var((string)$_POST['return'], FILTER_SANITIZE_URL);
+    if ($return !== '' && (parse_url($return, PHP_URL_SCHEME) !== null || parse_url($return, PHP_URL_HOST) !== null)) {
+        $return = '';
+    }
+}
 
 $log('Processing id=' . $id);
 
@@ -235,7 +242,7 @@ try {
             throw new RuntimeException('Commit failed');
         }
         $log('Update committed for id=' . $id);
-        wants_json() ? json_out(['ok'=>true,'id'=>$id]) : redirect_to('employees.php');
+        wants_json() ? json_out(['ok'=>true,'id'=>$id]) : redirect_to($return !== '' ? $return : 'employees.php');
     } else {
         $log('Inserting new employee');
         $ins = $pdo->prepare('INSERT INTO people (first_name,last_name,email,phone,address_line1,address_line2,city,state,postal_code,google_place_id,latitude,longitude) VALUES (:fn,:ln,:em,:ph,:a1,:a2,:city,:st,:pc,:pid,:lat,:lon)');
@@ -269,7 +276,7 @@ try {
             throw new RuntimeException('Commit failed');
         }
         $log('Insert committed for id=' . $newId);
-        wants_json() ? json_out(['ok'=>true,'id'=>$newId]) : redirect_to('employees.php');
+        wants_json() ? json_out(['ok'=>true,'id'=>$newId]) : redirect_to($return !== '' ? $return : 'employees.php');
     }
 } catch (Throwable $e) {
     $pdo->rollBack();

--- a/public/js/employee_form.js
+++ b/public/js/employee_form.js
@@ -3,6 +3,7 @@
     var form = document.getElementById('employeeForm');
     if (!form) return;
     var mode = form.getAttribute('data-mode') || 'add';
+    var returnUrl = form.getAttribute('data-return');
     var phoneEl = form.querySelector('#phone');
     if (phoneEl) {
       phoneEl.addEventListener('input', function (e) {
@@ -68,8 +69,8 @@
           try{window.dispatchEvent(new Event('employees:updated'));}catch(_){ }
           showToast(mode === 'edit' ? 'Employee updated' : 'Employee saved');
           setTimeout(function(){
-            var dest = 'employees.php';
-            if (mode === 'add' && data && data.id) {
+            var dest = returnUrl || 'employees.php';
+            if (!returnUrl && mode === 'add' && data && data.id) {
               var today = new Date();
               var diff = today.getDay() === 0 ? -6 : 1 - today.getDay();
               today.setDate(today.getDate() + diff);


### PR DESCRIPTION
## Summary
- allow employee form to capture an optional `return` URL and expose it via hidden and data attributes
- redirect cancel and post-save flows to the return URL when provided
- update client-side logic to respect the optional return destination

## Testing
- `php -l public/employee_form.php public/employee_save.php`
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*


------
https://chatgpt.com/codex/tasks/task_e_68a888322964832f9c773a3f102c3b07