### PR TITLE
Add return navigation support for job assignments

### DIFF
--- a/public/assignments_table.php
+++ b/public/assignments_table.php
@@ -104,8 +104,11 @@ foreach ($rows as $r) {
   $label = htmlspecialchars(str_replace('_',' ', $stat), ENT_QUOTES, 'UTF-8');
   echo "  <td><span class=\"badge bg-{$badgeClass}\">{$label}</span></td>";
   echo "  <td class=\"text-end\">";
-  echo "    <button type=\"button\" class=\"btn btn-sm btn-outline-primary btn-assign me-1\" data-bs-toggle=\"modal\" data-bs-target=\"#assignmentsModal\" data-job-id=\"{$jid}\">Assign</button>";
-  echo "    <a class=\"btn btn-sm btn-outline-secondary\" href=\"edit_job.php?id={$jid}\">Edit</a>";
+  $return = 'assignments.php';
+  $retEsc = htmlspecialchars($return, ENT_QUOTES, 'UTF-8');
+  $retUrl = rawurlencode($return);
+  echo "    <button type=\"button\" class=\"btn btn-sm btn-outline-primary btn-assign me-1\" data-bs-toggle=\"modal\" data-bs-target=\"#assignmentsModal\" data-job-id=\"{$jid}\" data-return=\"{$retEsc}\">Assign</button>";
+  echo "    <a class=\"btn btn-sm btn-outline-secondary\" href=\"edit_job.php?id={$jid}&return={$retUrl}\">Edit</a>";
   echo "  </td>";
   echo "</tr>";
 }

--- a/public/job_form.php
+++ b/public/job_form.php
@@ -17,6 +17,13 @@ $job         = $job ?? [];
 $jobSkillIds = $jobSkillIds ?? [];
 $jobTypeIds  = $jobTypeIds ?? [];
 $isEdit      = $mode === 'edit';
+$returnUrl   = '';
+if (isset($_GET['return'])) {
+    $returnUrl = filter_var((string)$_GET['return'], FILTER_SANITIZE_URL);
+    if ($returnUrl !== '' && (parse_url($returnUrl, PHP_URL_SCHEME) !== null || parse_url($returnUrl, PHP_URL_HOST) !== null)) {
+        $returnUrl = '';
+    }
+}
 
 $skills    = Skill::all($pdo);
 $statuses  = $isEdit ? Job::allowedStatuses() : array_intersect(['scheduled','draft'], Job::allowedStatuses());
@@ -66,8 +73,9 @@ function stickyArr(string $name, array $default = []): array {
       <p>Job not found.</p>
     <?php else: ?>
     <div id="form-errors" class="text-danger mb-3"></div>
-    <form id="jobForm" method="post" action="job_save.php" autocomplete="off" class="needs-validation" novalidate data-mode="<?= $isEdit ? 'edit' : 'add' ?>">
+    <form id="jobForm" method="post" action="job_save.php" autocomplete="off" class="needs-validation" novalidate data-mode="<?= $isEdit ? 'edit' : 'add' ?>" data-return="<?= s($returnUrl) ?>">
       <input type="hidden" name="csrf_token" value="<?= s($__csrf) ?>">
+      <input type="hidden" name="return" value="<?= s($returnUrl) ?>">
       <?php if ($isEdit): ?>
         <input type="hidden" name="id" value="<?= s((string)($job['id'] ?? '')) ?>">
       <?php endif; ?>
@@ -166,7 +174,8 @@ function stickyArr(string $name, array $default = []): array {
 
       <div class="mt-3">
         <button type="submit" class="btn btn-primary"><?= $isEdit ? 'Save Changes' : 'Save Job' ?></button>
-        <a href="jobs.php" class="btn btn-secondary">Cancel</a>
+        <?php $cancel = $returnUrl !== '' ? $returnUrl : 'jobs.php'; ?>
+        <a href="<?= s($cancel) ?>" class="btn btn-secondary">Cancel</a>
       </div>
     </form>
 

--- a/public/js/job_form.js
+++ b/public/js/job_form.js
@@ -3,6 +3,7 @@
     var form = document.getElementById('jobForm');
     if(!form) return;
     var mode = form.getAttribute('data-mode') || 'add';
+    var returnUrl = form.getAttribute('data-return');
     var errBox = document.getElementById('form-errors');
     var skillError = document.getElementById('jobSkillError');
     var initItems = window.initialChecklistItems || [];
@@ -197,7 +198,7 @@
         .then(function(data){
           if(data && data.ok){
             showToast(mode==='edit'?'Job updated':'Job saved');
-            setTimeout(function(){ window.location.href='jobs.php'; }, 800);
+            setTimeout(function(){ window.location.href = returnUrl || 'jobs.php'; }, 800);
             return;
           }
           var errs=[];


### PR DESCRIPTION
## Summary
- Allow Assign and Edit actions on assignments list to include a return URL to the listing
- Enable job form to read optional return URL, update cancel button, and redirect after save
- Accept return URL in job_save.php and redirect on success or failure when not requesting JSON

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a88aa9c71c832fbd992f05747fc0e3