### PR TITLE
Send start date and replace IDs when copying availability

### DIFF
--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -70,6 +70,7 @@ const copyModal = new bootstrap.Modal(copyModalEl);
 const copyForm = document.getElementById('copyForm');
 const copyDays = document.getElementById('copyDays');
 let copyBlocks = [];
+let copyStartDate = '';
 
 winModalEl.addEventListener('hide.bs.modal', () => {
   const active = document.activeElement;
@@ -364,6 +365,8 @@ function openEditDay(day, startDate = '') {
 
 function openCopy(day) {
   copyBlocks = (currentGroups[day] || []).map(it => ({ start_time: it.start_time, end_time: it.end_time }));
+  const first = currentGroups[day] && currentGroups[day][0];
+  copyStartDate = first && first.start_date ? first.start_date : '';
   copyDays.innerHTML = '';
   for (const d of daysOrder) {
     const id = 'copy-' + d;
@@ -704,7 +707,11 @@ copyForm.addEventListener('submit', async e => {
   const eid = currentEmployeeId();
   const days = Array.from(copyDays.querySelectorAll('input:checked')).map(i => i.value);
   if (!eid || days.length === 0 || copyBlocks.length === 0) { FieldOpsToast.show('Select target days', 'danger'); return; }
-  const payload = { csrf_token: CSRF, employee_id: eid, day_of_week: days, blocks: copyBlocks };
+  const replaceIds = [];
+  for (const d of days) {
+    (currentGroups[d] || []).forEach(it => replaceIds.push(it.id));
+  }
+  const payload = { csrf_token: CSRF, employee_id: eid, day_of_week: days, blocks: copyBlocks, start_date: copyStartDate, replace_ids: replaceIds };
   try {
     if (DEBUG) {
       console.log('Request to api/availability/create.php', payload, document.cookie);

--- a/tests/Integration/AvailabilityCopyTest.php
+++ b/tests/Integration/AvailabilityCopyTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../support/TestPdo.php';
+require_once __DIR__ . '/../support/TestDataFactory.php';
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+
+final class AvailabilityCopyTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = createTestPdo();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('DELETE FROM employee_availability');
+        $this->pdo->exec('DELETE FROM employees');
+        $this->pdo->exec('DELETE FROM people');
+    }
+
+    public function testCopyReplacesExistingWithStartDate(): void
+    {
+        $eid = TestDataFactory::createEmployee($this->pdo, 'Copy', 'Tester');
+        $startDate = '2024-01-01';
+        $this->pdo->prepare("INSERT INTO employee_availability (employee_id, day_of_week, start_time, end_time, start_date) VALUES (:e,'Monday','09:00:00','17:00:00',:sd)")
+            ->execute([':e' => $eid, ':sd' => $startDate]);
+        $st = $this->pdo->prepare("INSERT INTO employee_availability (employee_id, day_of_week, start_time, end_time, start_date) VALUES (:e,:d,'10:00:00','12:00:00',:sd)");
+        $st->execute([':e' => $eid, ':d' => 'Tuesday', ':sd' => $startDate]);
+        $tueId = (int)$this->pdo->lastInsertId();
+        $st->execute([':e' => $eid, ':d' => 'Wednesday', ':sd' => $startDate]);
+        $wedId = (int)$this->pdo->lastInsertId();
+
+        $res = EndpointHarness::run(
+            __DIR__ . '/../../public/api/availability/create.php',
+            [
+                'employee_id' => $eid,
+                'day_of_week' => ['Tuesday','Wednesday'],
+                'blocks' => [['start_time' => '09:00', 'end_time' => '17:00']],
+                'start_date' => $startDate,
+                'replace_ids' => [$tueId, $wedId],
+            ],
+            [],
+            'POST',
+            ['json' => true]
+        );
+
+        $this->assertTrue($res['ok'] ?? false, 'copy should succeed');
+
+        $stmt = $this->pdo->prepare("SELECT day_of_week,start_time,end_time,start_date FROM employee_availability WHERE employee_id=:e AND day_of_week IN ('Tuesday','Wednesday') ORDER BY day_of_week");
+        $stmt->execute([':e' => $eid]);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $this->assertCount(2, $rows);
+        foreach ($rows as $row) {
+            $this->assertSame('09:00:00', $row['start_time']);
+            $this->assertSame('17:00:00', $row['end_time']);
+            $this->assertSame($startDate, $row['start_date']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve source start date when copying availability windows and include it in copy payload
- Replace existing target-day windows by sending their IDs via `replace_ids`
- Extend test harness for JSON payloads and add integration test covering copy with start date

## Testing
- `./vendor/bin/phpunit tests/Integration/AvailabilityCopyTest.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a88e1e14fc832fa87e706ba2140a49