### PR TITLE
Fix job deletion CSRF

### DIFF
--- a/public/jobs.php
+++ b/public/jobs.php
@@ -90,7 +90,11 @@ require __DIR__ . '/../partials/header.php';
 
 <?php include __DIR__ . '/../partials/assignments_modal.php'; ?>
 <?php
+$csrfEsc = htmlspecialchars($CSRF, ENT_QUOTES, 'UTF-8');
 $pageScripts = <<<HTML
+<script>
+  window.CSRF_TOKEN = "{$csrfEsc}";
+</script>
 <script src="/js/assignments.js?v=20250812"></script>
 <script src="/js/jobs.js?v=20250812"></script>
 HTML;

--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -1,5 +1,6 @@
 // /public/js/jobs.js
 (() => {
+  const csrf = window.CSRF_TOKEN || '';
   function ready(fn){document.readyState!='loading'?fn():document.addEventListener('DOMContentLoaded',fn);}
   function h(s){const d=document.createElement('div');d.textContent=s==null?'':String(s);return d.innerHTML;}
   ready(() => {
@@ -110,7 +111,7 @@
         actCell.classList.add('text-nowrap');
         actCell.innerHTML=`<button class="btn btn-sm btn-outline-primary me-1" data-bs-toggle="modal" data-bs-target="#assignmentsModal" data-job-id="${job.job_id}">Assign</button>
 <a class="btn btn-sm btn-outline-secondary me-1" href="edit_job.php?id=${job.job_id}" target="_blank">Edit</a>
-<a class="btn btn-sm btn-outline-danger" href="job_delete.php?id=${job.job_id}" onclick="return confirm('Delete this job? This cannot be undone.');">Delete</a>`;
+<a class="btn btn-sm btn-outline-danger" href="job_delete.php?id=${job.job_id}&csrf_token=${encodeURIComponent(csrf)}" onclick="return confirm('Delete this job? This cannot be undone.');">Delete</a>`;
         tr.appendChild(actCell);
         $tbody.appendChild(tr);
       });


### PR DESCRIPTION
## Summary
- expose CSRF token on jobs page for front-end use
- include CSRF token in job deletion links

## Testing
- `vendor/bin/phpunit -c phpunit.xml tests/Integration/JobWriteRbacTest.php` *(fails: DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a890765dbc832f8038833239cda906