### PR TITLE
Add admin dashboard with RBAC enforcement

### DIFF
--- a/helpers/auth_helpers.php
+++ b/helpers/auth_helpers.php
@@ -42,12 +42,10 @@ if (!function_exists('current_role')) {
 
 if (!function_exists('require_role')) {
     function require_role(string $role): void {
-        // Role checks disabled; function intentionally left blank.
-        return;
-        // if (current_role() !== $role) {
-        //     \JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-        //     exit;
-        // }
+        if (current_role() !== $role) {
+            \JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+            exit;
+        }
     }
 }
 

--- a/public/admin.php
+++ b/public/admin.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+header('Location: /admin/index.php');
+exit;

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+
+$title = 'Admin Dashboard';
+require_once __DIR__ . '/../../partials/header.php';
+require_once __DIR__ . '/nav.php';
+?>
+<h1 class="h4 mb-3">Admin Tools</h1>
+<ul>
+  <li><a href="/admin/job_type_list.php">Job Types</a></li>
+  <li><a href="/admin/checklist_template_list.php">Checklists</a></li>
+  <li><a href="/admin/skill_list.php">Skills</a></li>
+</ul>
+<?php require_once __DIR__ . '/../../partials/footer.php'; ?>

--- a/tests/Integration/AdminDashboardAuthTest.php
+++ b/tests/Integration/AdminDashboardAuthTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class AdminDashboardAuthTest extends TestCase
+{
+    public function testNonAdminIsForbidden(): void
+    {
+        $target = __DIR__ . '/../../public/admin/index.php';
+        $tmp = tempnam(sys_get_temp_dir(), 'fo');
+        $php = <<<'PHP'
+<?php
+session_id('t-' . bin2hex(random_bytes(3)));
+session_start();
+$_SESSION['role'] = 'dispatcher';
+define('FIELDOPS_ALLOW_ENDPOINT_EXECUTION', true);
+$GLOBALS['__FIELDOPS_TEST_CALL__'] = true;
+require '%s';
+PHP;
+        $code = sprintf($php, addslashes($target));
+        file_put_contents($tmp, $code);
+        $out = shell_exec('php ' . escapeshellarg($tmp));
+        unlink($tmp);
+        $res = json_decode((string)$out, true);
+        $this->assertFalse($res['ok'] ?? true);
+        $this->assertSame(403, $res['code'] ?? 0);
+    }
+
+    public function testAdminCanAccess(): void
+    {
+        $target = __DIR__ . '/../../public/admin/index.php';
+        $tmp = tempnam(sys_get_temp_dir(), 'fo');
+        $php = <<<'PHP'
+<?php
+session_id('t-' . bin2hex(random_bytes(3)));
+session_start();
+$_SESSION['role'] = 'admin';
+define('FIELDOPS_ALLOW_ENDPOINT_EXECUTION', true);
+$GLOBALS['__FIELDOPS_TEST_CALL__'] = true;
+require '%s';
+PHP;
+        $code = sprintf($php, addslashes($target));
+        file_put_contents($tmp, $code);
+        $out = shell_exec('php ' . escapeshellarg($tmp));
+        unlink($tmp);
+        $this->assertStringContainsString('Admin Tools', (string)$out);
+    }
+}


### PR DESCRIPTION
## Summary
- add admin dashboard index with links to job type, checklist, and skill tools
- redirect /admin to the new dashboard
- enforce role checking and add tests for admin dashboard access

## Testing
- `./vendor/bin/phpunit tests/Integration/AdminPageAuthTest.php tests/Integration/AdminDashboardAuthTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8aca7f498832f885dca90787cabbc