### PR TITLE
Add job deletion logging and admin history view

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -387,6 +387,21 @@ if (!tableExists($pdo, 'job_checklist_items')) {
     out('[OK] job_checklist_items created');
 }
 
+// Ensure job_deletion_log table
+if (!tableExists($pdo, 'job_deletion_log')) {
+    out('[..] Creating table job_deletion_log ...');
+    $pdo->exec(
+        "CREATE TABLE `job_deletion_log` (
+            `id` INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            `job_id` INT NOT NULL,
+            `user_id` INT NULL,
+            `reason` VARCHAR(255) NULL,
+            `deleted_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+    );
+    out('[OK] job_deletion_log created');
+}
+
 // Drop deprecated job_jobtype table if present
 if (tableExists($pdo, 'job_jobtype')) {
     out('[..] Dropping table job_jobtype ...');
@@ -416,7 +431,7 @@ if (tableExists($pdo, 'employee_availability_overrides')) {
 }
 
 out("== Ensuring PRIMARY KEYS ==");
-foreach (['people','employees','job_types','employee_availability_overrides','availability_audit','job_checklist_items'] as $t) {
+foreach (['people','employees','job_types','employee_availability_overrides','availability_audit','job_checklist_items','job_deletion_log'] as $t) {
     ensureAutoPk($pdo, $t);
 }
 
@@ -453,6 +468,8 @@ ensureFk($pdo, 'job_employee_assignment', 'employee_id', 'employees', 'id', 'fk_
 
 ensureFk($pdo, 'employee_availability_overrides', 'employee_id', 'employees', 'id', 'fk_eao_employee', 'CASCADE', 'CASCADE');
 ensureFk($pdo, 'availability_audit', 'employee_id', 'employees', 'id', 'fk_avail_audit_employee', 'CASCADE', 'CASCADE');
+ensureFk($pdo, 'job_deletion_log', 'job_id', 'jobs', 'id', 'fk_job_deletion_log_job', 'CASCADE', 'CASCADE');
+ensureFk($pdo, 'job_deletion_log', 'user_id', 'employees', 'id', 'fk_job_deletion_log_user', 'SET NULL', 'CASCADE');
 
 out(PHP_EOL . "== Ensuring people name columns and index ==");
 ensureVarchar100NotNull($pdo, 'people', 'first_name');

--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -18,5 +18,6 @@ require_once __DIR__ . '/nav.php';
   <li><a href="/admin/job_type_list.php">Job Types</a></li>
   <li><a href="/admin/checklist_template_list.php">Checklists</a></li>
   <li><a href="/admin/skill_list.php">Skills</a></li>
+  <li><a href="/admin/job_deletion_log.php">Job Deletion Log</a></li>
 </ul>
 <?php require_once __DIR__ . '/../../partials/footer.php'; ?>

--- a/public/admin/job_deletion_log.php
+++ b/public/admin/job_deletion_log.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/../_cli_guard.php';
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+require_once __DIR__ . '/../_auth.php';
+require_role('admin');
+require_once __DIR__ . '/../../config/database.php';
+
+$pdo = getPDO();
+$st = $pdo->query(
+    "SELECT jdl.job_id, jdl.user_id, jdl.reason, jdl.deleted_at, p.first_name, p.last_name
+     FROM job_deletion_log jdl
+     LEFT JOIN employees e ON e.id = jdl.user_id
+     LEFT JOIN people p ON p.id = e.person_id
+     ORDER BY jdl.deleted_at DESC"
+);
+$rows = $st ? $st->fetchAll(PDO::FETCH_ASSOC) : [];
+function s(?string $v): string { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Job Deletion Log</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-3">
+  <div class="d-flex align-items-center mb-3">
+    <h1 class="h4 m-0">Job Deletion Log</h1>
+    <a href="index.php" class="btn btn-sm btn-secondary ms-auto">Back</a>
+  </div>
+  <div class="card">
+    <div class="table-responsive">
+      <table class="table table-striped table-hover m-0">
+        <thead class="table-light">
+          <tr><th>Job ID</th><th>User</th><th>Reason</th><th>Deleted At</th></tr>
+        </thead>
+        <tbody>
+        <?php foreach ($rows as $r): ?>
+          <?php
+            $name = trim(((string)($r['first_name'] ?? '')) . ' ' . ((string)($r['last_name'] ?? '')));
+            $userDisplay = $name !== '' ? $name : ((isset($r['user_id']) && $r['user_id'] !== null) ? (string)$r['user_id'] : '-');
+          ?>
+          <tr>
+            <td><?= (int)$r['job_id'] ?></td>
+            <td><?= s($userDisplay) ?></td>
+            <td><?= s($r['reason'] ?? '') ?></td>
+            <td><?= s($r['deleted_at']) ?></td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/public/job_delete.php
+++ b/public/job_delete.php
@@ -60,6 +60,11 @@ try {
 
   $pdo->beginTransaction();
 
+  $uid = $_SESSION['user']['id'] ?? null;
+  $reason = (string)($_POST['reason'] ?? $_GET['reason'] ?? '');
+  $log = $pdo->prepare('INSERT INTO job_deletion_log (job_id, user_id, reason) VALUES (:jid,:uid,:reason)');
+  $log->execute([':jid'=>$id, ':uid'=>$uid, ':reason'=>$reason]);
+
   $upd = $pdo->prepare('UPDATE jobs SET deleted_at = NOW() WHERE id = :id');
   $upd->execute([':id'=>$id]);
   $changed = $upd->rowCount();

--- a/tests/migrations/20241004170000_create_job_deletion_log.sql
+++ b/tests/migrations/20241004170000_create_job_deletion_log.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS job_deletion_log (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    job_id INT UNSIGNED NOT NULL,
+    user_id INT UNSIGNED NULL,
+    reason VARCHAR(255) NULL,
+    deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_job_deletion_log_job_id (job_id),
+    INDEX idx_job_deletion_log_user_id (user_id),
+    CONSTRAINT fk_job_deletion_log_job FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,
+    CONSTRAINT fk_job_deletion_log_user FOREIGN KEY (user_id) REFERENCES employees(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- log deletions in new `job_deletion_log` table
- record job deletions in `job_delete.php`
- add admin page to review deletion history

## Testing
- `php scripts/migrate_test_db.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8af7f4c20832fbf631dfd83e2fbac