### PR TITLE
Add roles link to admin dashboard and verify access

### DIFF
--- a/public/admin/index.php
+++ b/public/admin/index.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/nav.php';
   <li><a href="/admin/job_type_list.php">Job Types</a></li>
   <li><a href="/admin/checklist_template_list.php">Checklists</a></li>
   <li><a href="/admin/skill_list.php">Skills</a></li>
+  <li><a href="/admin/role_list.php">Roles</a></li>
   <li><a href="/admin/job_deletion_log.php">Job Deletion Log</a></li>
 </ul>
 <?php require_once __DIR__ . '/../../partials/footer.php'; ?>

--- a/tests/Integration/AdminDashboardAuthTest.php
+++ b/tests/Integration/AdminDashboardAuthTest.php
@@ -45,5 +45,6 @@ PHP;
         $out = shell_exec('php ' . escapeshellarg($tmp));
         unlink($tmp);
         $this->assertStringContainsString('Admin Tools', (string)$out);
+        $this->assertStringContainsString('Roles', (string)$out);
     }
 }


### PR DESCRIPTION
## Summary
- Link to roles management from the admin dashboard
- Cover admin dashboard access in feature tests

## Testing
- `vendor/bin/phpunit tests/Integration/AdminDashboardAuthTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68a8b1db5624832f83ce03c94e24d3ed