### PR TITLE
Ensure primary key for job_employee_assignment table

### DIFF
--- a/bin/ensure_core_schema.php
+++ b/bin/ensure_core_schema.php
@@ -444,7 +444,7 @@ if (tableExists($pdo, 'employee_availability_overrides')) {
 }
 
 out("== Ensuring PRIMARY KEYS ==");
-foreach (['people','employees','job_types','employee_availability_overrides','availability_audit','job_checklist_items','job_deletion_log'] as $t) {
+foreach (['people','employees','job_types','employee_availability_overrides','availability_audit','job_checklist_items','job_deletion_log','job_employee_assignment'] as $t) {
     ensureAutoPk($pdo, $t);
 }
 


### PR DESCRIPTION
## Summary
- ensure auto-incrementing primary key for `job_employee_assignment`

## Testing
- `php bin/ensure_core_schema.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `php bin/schema_check.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `php -l bin/ensure_core_schema.php`
- `vendor/bin/phpunit tests/Unit`
- `vendor/bin/phpunit tests/Integration` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b7399a48832f833e14951c664151