### PR TITLE
Add migration to fix job employee assignment IDs

### DIFF
--- a/db/migrations/20241201000000_fix_jea_ids.sql
+++ b/db/migrations/20241201000000_fix_jea_ids.sql
@@ -1,0 +1,8 @@
+-- Assign unique IDs and enforce primary key on job_employee_assignment
+SET @i := 0;
+UPDATE job_employee_assignment
+SET id = (@i:=@i+1)
+ORDER BY job_id, employee_id;
+
+ALTER TABLE job_employee_assignment
+    MODIFY COLUMN id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY;


### PR DESCRIPTION
## Summary
- add migration to assign unique IDs to `job_employee_assignment` rows and enforce an auto-incrementing primary key

## Testing
- `php bin/ensure_core_schema.php` (fails: DB connection refused)
- `vendor/bin/phpunit` (fails: connection refused / missing tables)


------
https://chatgpt.com/codex/tasks/task_e_68a8bdc2c708832f9226314588753608