### PR TITLE
Add Job ID column to jobs table

### DIFF
--- a/public/jobs.php
+++ b/public/jobs.php
@@ -74,6 +74,7 @@ require __DIR__ . '/../partials/header.php';
       <table class="table table-striped table-hover m-0 table-jobs sticky-header" id="jobs-table">
         <thead class="table-light">
           <tr>
+            <th>Job&nbsp;ID</th>
             <th>Date</th>
             <th>Time</th>
             <th>Customer</th>

--- a/public/js/jobs.js
+++ b/public/js/jobs.js
@@ -34,7 +34,7 @@
         renderRows(data);
       }catch(err){
         console.error('loadJobs failed',err);
-        $tbody.innerHTML=`<tr><td colspan="7" class="text-danger">${h(err.message||'Failed to load jobs')}</td></tr>`;
+        $tbody.innerHTML=`<tr><td colspan="8" class="text-danger">${h(err.message||'Failed to load jobs')}</td></tr>`;
       }
     }
 
@@ -44,11 +44,15 @@
       const ret=encodeURIComponent(window.location.pathname.replace(/^\//,'')+window.location.search);
       $tbody.innerHTML='';
       if(!rows.length){
-        $tbody.innerHTML='<tr><td colspan="7" class="text-center text-muted py-3">No jobs match your filters</td></tr>';
+        $tbody.innerHTML='<tr><td colspan="8" class="text-center text-muted py-3">No jobs match your filters</td></tr>';
         return;
       }
       rows.forEach(job=>{
         const tr=document.createElement('tr');
+        // ID
+        const idCell=document.createElement('td');
+        idCell.textContent=job.job_id;
+        tr.appendChild(idCell);
         // Date
         const dateCell=document.createElement('td');
         let dLabel='';


### PR DESCRIPTION
## Summary
- show Job ID in jobs table header
- render Job ID cells for each job row and fix colspan counts

## Testing
- `make test` *(fails: DB connection refused)*
- `make lint` *(fails: Found 337 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cdbe4a48832f8babc4a0b24cb0c6