### PR TITLE
Render raw availability when schedule empty

### DIFF
--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -410,7 +410,8 @@ async function loadAvailability() {
     openOvEdit,
     delOverride: ov => delOverride(ov, loadAvailability)
   }, { weekStart: ws });
-  renderCalendar(calendar, data.events, data.overrides, jobs, ws, eid);
+  const events = Array.isArray(data.events) && data.events.length ? data.events : data.availability;
+  renderCalendar(calendar, events, data.overrides, jobs, ws, eid);
 }
 
 winForm.addEventListener('submit', async (e) => {

--- a/public/js/calendar-render.js
+++ b/public/js/calendar-render.js
@@ -15,13 +15,24 @@ export function renderCalendar(calendar, availability, overrides, jobs, weekStar
   let added = 0;
 
   for (const it of Array.isArray(availability) ? availability : []) {
-    if (!it.start || !it.end) continue;
-    if (it.start >= it.end) continue;
+    let { start, end } = it;
+    if (!start || !end) {
+      if (!weekStart || !it.day_of_week || !it.start_time || !it.end_time) continue;
+      const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+      const idx = days.indexOf(it.day_of_week);
+      if (idx === -1) continue;
+      const base = new Date(weekStart + 'T00:00:00');
+      base.setDate(base.getDate() + idx);
+      const date = base.toISOString().slice(0,10);
+      start = `${date}T${it.start_time}`;
+      end = `${date}T${it.end_time}`;
+    }
+    if (start >= end) continue;
     const color = '#198754';
     calendar.addEvent({
       id: 'win-' + it.id,
-      start: it.start,
-      end: it.end,
+      start,
+      end,
       backgroundColor: color,
       borderColor: color,
       editable: true,


### PR DESCRIPTION
## Summary
- Fallback to availability data when no scheduled events exist
- Compute calendar entries from day-of-week availability records

## Testing
- `npm test` *(fails: Could not read package.json)*
- `make lint` *(fails: Found 337 errors)*
- `make test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d6cb6f48832f97c00078b0deb863