### PR TITLE
Handle SQLite upsert for job completion signatures

### DIFF
--- a/models/JobCompletion.php
+++ b/models/JobCompletion.php
@@ -7,10 +7,13 @@ final class JobCompletion
      */
     public static function save(PDO $pdo, int $jobId, string $signaturePath): bool
     {
-        $st = $pdo->prepare(
-            'INSERT INTO job_completion (job_id, signature_path) VALUES (:jid, :sp)
-             ON DUPLICATE KEY UPDATE signature_path = VALUES(signature_path)'
-        );
+        $sql = 'INSERT INTO job_completion (job_id, signature_path) VALUES (:jid, :sp)';
+        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) === 'sqlite') {
+            $sql .= ' ON CONFLICT(job_id) DO UPDATE SET signature_path=excluded.signature_path';
+        } else {
+            $sql .= ' ON DUPLICATE KEY UPDATE signature_path = VALUES(signature_path)';
+        }
+        $st = $pdo->prepare($sql);
         if ($st === false) {
             return false;
         }


### PR DESCRIPTION
## Summary
- Branch on PDO driver when saving job completion signatures
- Use SQLite-specific `ON CONFLICT` clause to upsert `signature_path`

## Testing
- `make lint` (fails: 346 errors)
- `make test` (fails: integration tests report failures)


------
https://chatgpt.com/codex/tasks/task_e_68aa57436b90832fb97f14b368da6c1d