### PR TITLE
Use parameterized timestamps in job and audit models

### DIFF
--- a/models/AuditLog.php
+++ b/models/AuditLog.php
@@ -9,14 +9,16 @@ final class AuditLog
      * @param int|null   $userId  User performing the action
      * @param string     $action  Action identifier
      * @param array|string|null $details Additional details encoded as JSON if array
+     * @param string|null $now   Timestamp to use for created_at
      */
-    public static function insert(PDO $pdo, ?int $userId, string $action, array|string|null $details = null): void
+    public static function insert(PDO $pdo, ?int $userId, string $action, array|string|null $details = null, ?string $now = null): void
     {
         try {
             $det = is_array($details) ? json_encode($details, JSON_UNESCAPED_UNICODE) : $details;
-            $st = $pdo->prepare('INSERT INTO audit_log (user_id, action, details, created_at) VALUES (:uid,:act,:det,NOW())');
+            $now = $now ?? date('Y-m-d H:i:s');
+            $st = $pdo->prepare('INSERT INTO audit_log (user_id, action, details, created_at) VALUES (:uid,:act,:det,:now)');
             if ($st !== false) {
-                $st->execute([':uid' => $userId, ':act' => $action, ':det' => $det]);
+                $st->execute([':uid' => $userId, ':act' => $action, ':det' => $det, ':now' => $now]);
             }
         } catch (Throwable) {
             // swallow logging errors


### PR DESCRIPTION
## Summary
- allow passing explicit timestamps to `AuditLog::insert`
- parameterize job timestamp updates for delete, start, and complete

## Testing
- `make lint` *(fails: Function csrf_token not found; [ERROR] Found 345 errors)*
- `make test` *(fails: ...FF..FFFF...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa57ddc784832f973a7128f8b134af