### PR TITLE
Add FullCalendar POC and docs

### DIFF
--- a/docs/poc_availability_calendar.md
+++ b/docs/poc_availability_calendar.md
@@ -11,7 +11,7 @@ This demo page renders availability, overrides and scheduled jobs on a calendar.
    php -S 127.0.0.1:8010 -t public
    ```
 2. Visit [http://127.0.0.1:8010/poc_availability_calendar.php](http://127.0.0.1:8010/poc_availability_calendar.php).
-3. The page uses `initCalendar` and `renderCalendar` from `js/calendar-render.js` with sample data.
+3. FullCalendar CSS/JS is loaded from the jsDelivr CDN and the page imports `initCalendar` and `renderCalendar` from `js/calendar-render.js` with sample data.
 
 ### What to look for
 

--- a/public/poc_availability_calendar.php
+++ b/public/poc_availability_calendar.php
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Availability Calendar POC</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
 </head>
 <body class="p-3">
   <div id="calendar"></div>


### PR DESCRIPTION
## Summary
- demo calendar page loads FullCalendar via CDN and renders sample availability
- onboarding guide for calendar POC in docs

## Testing
- `make test` *(fails: AssignmentConflictTest Rejects overlapping assignments)*


------
https://chatgpt.com/codex/tasks/task_e_68aa5a33a22c832f8e6159dcd3a8f22d