### PR TITLE
Use FullCalendar CDN on availability manager

### DIFF
--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -104,7 +104,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
 $title = 'Availability Manager';
 $bodyAttrs = 'data-csrf="' . s($__csrf) . '"';
 $headExtra = <<<HTML
-  <link href="https://uicdn.toast.com/tui.calendar/latest/toastui-calendar.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
   <style>
     body { padding: 24px; }
     .day-badge { min-width: 90px; display: inline-block; }
@@ -515,7 +515,7 @@ require __DIR__ . '/../partials/header.php';
 </div>
 <?php
 $pageScripts = <<<HTML
-<script src="https://uicdn.toast.com/tui.calendar/latest/toastui-calendar.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
 <script type="module" src="/js/availability-manager.js"></script>
 HTML;
 require __DIR__ . '/../partials/footer.php';

--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -1,6 +1,6 @@
 import { fetchAvailability, fetchJobs } from './availability-fetch.js';
 import { renderList, showAlert, hideAlert, currentGroups, allGroups } from './list-render.js';
-import { initCalendar, renderCalendar } from './tui-calendar-render.js';
+import { initCalendar, renderCalendar } from './calendar-render.js';
 import { openOvAdd, openOvEdit, delOverride } from './override-handlers.js';
 
 const DEBUG = false;


### PR DESCRIPTION
## Summary
- Load FullCalendar via `index.global.min.css/js` instead of TUI Calendar
- Drop TUI-specific assets and keep `availability-manager.js`
- Update availability-manager script to use FullCalendar renderer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `vendor/bin/phpunit` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b935378832f826c3db89610c325