### PR TITLE
Switch to FullCalendar for availability manager

### DIFF
--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -104,7 +104,7 @@ $selectedEmployeeId = isset($_GET['employee_id']) ? (int)$_GET['employee_id'] : 
 $title = 'Availability Manager';
 $bodyAttrs = 'data-csrf="' . s($__csrf) . '"';
 $headExtra = <<<HTML
-  <link href="https://uicdn.toast.com/tui.calendar/latest/toastui-calendar.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet">
   <style>
     body { padding: 24px; }
     .day-badge { min-width: 90px; display: inline-block; }
@@ -515,7 +515,7 @@ require __DIR__ . '/../partials/header.php';
 </div>
 <?php
 $pageScripts = <<<HTML
-<script src="https://uicdn.toast.com/tui.calendar/latest/toastui-calendar.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
 <script type="module" src="/js/availability-manager.js"></script>
 HTML;
 require __DIR__ . '/../partials/footer.php';

--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -1,6 +1,6 @@
 import { fetchAvailability, fetchJobs } from './availability-fetch.js';
 import { renderList, showAlert, hideAlert, currentGroups, allGroups } from './list-render.js';
-import { initCalendar, renderCalendar } from './tui-calendar-render.js';
+import { initCalendar, renderCalendar } from './calendar-render.js';
 import { openOvAdd, openOvEdit, delOverride } from './override-handlers.js';
 
 const DEBUG = false;


### PR DESCRIPTION
## Summary
- Use FullCalendar renderer in availability manager
- Load FullCalendar assets instead of Toast UI calendar

## Testing
- `npm run test:ui` *(fails: Process from config.webServer exited early)*
- `make unit`
- `./vendor/bin/phpunit tests/Integration --testdox --stop-on-failure` *(fails: Assignment Conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68aa61414e78832fa996cd2bc0e6db72