### PR TITLE
chore: remove TUI calendar build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ from your local development configuration.
 When including scripts from a CDN, always add an `integrity` hash and
 `crossorigin="anonymous"` attribute. These enable Subresource Integrity (SRI),
 helping ensure the fetched resources have not been tampered with.
+
+The application currently loads [FullCalendar](https://fullcalendar.io/) from
+the jsDelivr CDN. If you need offline support, install the appropriate
+`@fullcalendar/*` packages with npm and bundle them locally instead of relying
+on the CDN.

--- a/package.json
+++ b/package.json
@@ -8,16 +8,12 @@
     "test": "tests"
   },
   "scripts": {
-    "test:ui": "playwright test",
-    "build:tui-calendar": "esbuild node_modules/@toast-ui/calendar/dist/toastui-calendar.js --bundle --minify --format=esm --outfile=public/js/tui-calendar.min.js"
+    "test:ui": "playwright test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
-  "dependencies": {
-    "@toast-ui/calendar": "^2.1.3"
-  },
   "devDependencies": {
     "@playwright/test": "^1.41.2",
     "esbuild": "^0.19.12"


### PR DESCRIPTION
## Summary
- remove toast UI calendar build script
- drop TUI calendar dependency
- note FullCalendar CDN usage and offline install option

## Testing
- `npm test` (fails: Missing script "test")
- `make test` (fails: integration tests failing)


------
https://chatgpt.com/codex/tasks/task_e_68aa6274e5b0832f93c34b5dec5db3e0