### PR TITLE
Render availability calendar on tab show event

### DIFF
--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -227,6 +227,7 @@ function handleEventEdit(ev) {
 }
 
 const calendar = initCalendar(handleSelect, handleEventEdit);
+document.getElementById('calendar-tab').addEventListener('shown.bs.tab', () => calendar.render(), { once: true });
 
 async function searchEmployees() {
   hideAlert();


### PR DESCRIPTION
## Summary
- render availability calendar only after its tab is shown to ensure proper layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:ui` *(fails: Timed out waiting 60000ms from config.webServer)*
- `vendor/bin/phpunit --stop-on-failure` *(fails: AssignmentConflictTest::testRejectsOverlappingAssignments)*

------
https://chatgpt.com/codex/tasks/task_e_68ab133431e4832f9eb965fcca88785e