### PR TITLE
Add loading spinner to availability calendar

### DIFF
--- a/public/availability_manager.php
+++ b/public/availability_manager.php
@@ -236,6 +236,7 @@ require __DIR__ . '/../partials/header.php';
         </div>
       </div>
       <div class="tab-pane fade" id="calendarView" role="tabpanel">
+        <div id="calendarLoading" class="text-center py-3">Loading…</div>
         <div id="calendar" class="mt-3"></div>
         <div id="calendarEmpty" class="text-muted text-center py-3 d-none">No calendar events</div>
       </div>

--- a/public/js/availability-manager.js
+++ b/public/js/availability-manager.js
@@ -23,6 +23,8 @@ const weekDisplay = document.getElementById('weekDisplay');
 
 const btnExport = document.getElementById('btnExport');
 const btnPrint = document.getElementById('btnPrint');
+const calendarEl = document.getElementById('calendar');
+const calendarLoading = document.getElementById('calendarLoading');
 
 const bulkAction = document.getElementById('bulk_action');
 const bulkApply = document.getElementById('bulk_apply');
@@ -400,6 +402,8 @@ async function delRow(it) {
 async function loadAvailability() {
   const eid = currentEmployeeId();
   const ws = currentWeekStart();
+  calendarLoading.classList.remove('d-none');
+  calendarEl.classList.add('d-none');
   const [data, jobs] = await Promise.all([
     fetchAvailability(eid, ws),
     eid ? fetchJobs(ws) : Promise.resolve([])
@@ -413,6 +417,8 @@ async function loadAvailability() {
   }, { weekStart: ws });
   const events = Array.isArray(data.events) && data.events.length ? data.events : data.availability;
   renderCalendar(calendar, events, data.overrides, jobs, ws, eid);
+  calendarLoading.classList.add('d-none');
+  calendarEl.classList.remove('d-none');
 }
 
 winForm.addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- Display loading message before calendar fetch
- Toggle calendar visibility during loading for a smoother UX

## Testing
- `npm test` *(fails: Missing script "test")*
- `make test` *(fails: TypeError: is_file(): Argument #1 ($filename) must be of type string, null given)*


------
https://chatgpt.com/codex/tasks/task_e_68ab14844cf0832f9af769bfd797d467