### PR TITLE
Add login page with header and redirect

### DIFF
--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+  session_start();
+}
+
+$role = $_SESSION['role'] ?? 'guest';
+if ($role !== 'guest') {
+  switch ($role) {
+    case 'admin':
+      header('Location: /admin/index.php');
+      break;
+    case 'field_tech':
+      header('Location: /tech_jobs.php');
+      break;
+    default:
+      header('Location: /jobs.php');
+      break;
+  }
+  exit;
+}
+
+$title = 'Log In';
+require __DIR__ . '/../partials/header.php';
+?>
+  <div class="row justify-content-center">
+    <div class="col-md-4">
+      <form id="login-form" action="/api/login.php" method="post" class="card card-body">
+        <div class="mb-3">
+          <label for="username" class="form-label">Username or Email</label>
+          <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="mb-3">
+          <label for="password" class="form-label">Password</label>
+          <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <?php require __DIR__ . '/../partials/csrf_input.php'; ?>
+        <div class="d-grid mb-3">
+          <button type="submit" class="btn btn-primary">Log In</button>
+        </div>
+        <div class="text-center"><a href="/forgot_password.php">Forgot password?</a></div>
+        <div id="login-error" class="text-danger mt-3 d-none">Invalid credentials</div>
+      </form>
+    </div>
+  </div>
+<?php
+$pageScripts = <<<HTML
+<script>
+(function(){
+  const form = document.getElementById('login-form');
+  const err = document.getElementById('login-error');
+  form.addEventListener('submit', async function(ev){
+    ev.preventDefault();
+    err.classList.add('d-none');
+    const fd = new FormData(form);
+    try {
+      const res = await fetch(form.action, {method:'POST', body:fd});
+      const data = await res.json();
+      if(res.ok && data && data.ok){
+        let dest = '/jobs.php';
+        if(data.role === 'admin'){ dest = '/admin/index.php'; }
+        else if(data.role === 'field_tech'){ dest = '/tech_jobs.php'; }
+        window.location.href = dest;
+      } else {
+        err.classList.remove('d-none');
+      }
+    } catch(e) {
+      err.classList.remove('d-none');
+    }
+  });
+})();
+</script>
+HTML;
+require __DIR__ . '/../partials/footer.php';
+?>


### PR DESCRIPTION
## Summary
- add a login form using header/footer partials
- redirect already authenticated users to their dashboards
- post login credentials to /api/login.php with generic error handling

## Testing
- `php -l public/login.php`
- `vendor/bin/phpunit` *(fails: FF..FFFF)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20a5822c832f95ec05b78b5ff3b9