### PR TITLE
Add logout API endpoint

### DIFF
--- a/public/api/logout.php
+++ b/public/api/logout.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+}
+session_destroy();
+
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode(['ok' => true], JSON_UNESCAPED_SLASHES);
+


### PR DESCRIPTION
## Summary
- add API endpoint to destroy session and clear session cookie for logout

## Testing
- `vendor/bin/phpunit` *(fails: ...................FF..FFFF...)*


------
https://chatgpt.com/codex/tasks/task_e_68ab23a13aa4832fbca04b44496ece47