### PR TITLE
Add secure session bootstrap with inactivity timeouts

### DIFF
--- a/helpers/session.php
+++ b/helpers/session.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+// Session bootstrap for FieldOps
+// Sets secure cookie parameters and enforces inactivity/absolute timeouts.
+
+$cookieParams = [
+    'httponly' => true,
+    'secure' => true,
+    'samesite' => 'Strict',
+];
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_set_cookie_params($cookieParams);
+    session_start();
+}
+
+$now = time();
+$inactiveLimit = 30 * 60; // 30 minutes
+$absoluteLimit = 12 * 60 * 60; // 12 hours
+
+$created = $_SESSION['created_at'] ?? $now;
+$last = $_SESSION['last_activity'] ?? $now;
+
+if (($now - $last) > $inactiveLimit || ($now - $created) > $absoluteLimit) {
+    session_unset();
+    session_destroy();
+
+    if (PHP_SAPI !== 'cli') {
+        $uri = $_SERVER['REQUEST_URI'] ?? '';
+        if (str_starts_with($uri, '/api/')) {
+            http_response_code(401);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Session expired']);
+        } else {
+            header('Location: /login.php');
+        }
+    }
+    exit;
+}
+
+$_SESSION['last_activity'] = $now;
+if (!isset($_SESSION['created_at'])) {
+    $_SESSION['created_at'] = $now;
+}

--- a/public/_cli_guard.php
+++ b/public/_cli_guard.php
@@ -36,3 +36,6 @@ if (PHP_SAPI === 'cli') {
         return;
     }
 }
+
+// Initialize session handling for web requests
+require_once __DIR__ . '/../helpers/session.php';

--- a/public/api/assignments/assign.php
+++ b/public/api/assignments/assign.php
@@ -2,6 +2,8 @@
 // /public/api/assignments/assign.php
 declare(strict_types=1);
 
+require dirname(__DIR__, 2) . '/_cli_guard.php';
+
 header('Content-Type: application/json');
 
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }

--- a/public/api/availability/bulk_copy.php
+++ b/public/api/availability/bulk_copy.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require dirname(__DIR__, 2) . '/_cli_guard.php';
+
 header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../../../config/database.php';
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }

--- a/public/api/availability/bulk_reset.php
+++ b/public/api/availability/bulk_reset.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require dirname(__DIR__, 2) . '/_cli_guard.php';
+
 header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../../../config/database.php';
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }

--- a/public/api/availability/create.php
+++ b/public/api/availability/create.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require dirname(__DIR__, 2) . '/_cli_guard.php';
+
 /**
  * POST /api/availability/create.php
  * Save or update recurring availability windows.

--- a/public/api/availability/override.php
+++ b/public/api/availability/override.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require dirname(__DIR__, 2) . '/_cli_guard.php';
+
 /**
  * POST /api/availability/override.php
  * Create or update date-specific availability overrides.

--- a/public/api/availability/override_delete.php
+++ b/public/api/availability/override_delete.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require dirname(__DIR__, 2) . '/_cli_guard.php';
+
 /**
  * DELETE /api/availability/override_delete.php?id=123
  * Remove an override by id.

--- a/public/assignment_process.php
+++ b/public/assignment_process.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require __DIR__ . '/_cli_guard.php';
+
 require_once __DIR__ . '/../config/database.php';
 header('Content-Type: application/json; charset=utf-8');
 

--- a/public/dev_login.php
+++ b/public/dev_login.php
@@ -9,6 +9,8 @@
 
 declare(strict_types=1);
 
+require __DIR__ . '/_cli_guard.php';
+
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
 }

--- a/public/dev_logout.php
+++ b/public/dev_logout.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
 /** DEV-ONLY logout shim (localhost + test) */
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 $ip = $_SERVER['REMOTE_ADDR'] ?? '';

--- a/public/dev_whoami.php
+++ b/public/dev_whoami.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+require __DIR__ . '/_cli_guard.php';
 if (session_status() !== PHP_SESSION_ACTIVE) { session_start(); }
 
 $ip = $_SERVER['REMOTE_ADDR'] ?? '(none)';


### PR DESCRIPTION
## Summary
- add helpers/session.php to configure secure cookies and enforce inactivity/absolute timeouts
- load session bootstrap from _cli_guard.php for all public entry points
- ensure API and dev endpoints require the guard before touching sessions

## Testing
- `make lint` (fails: Found 346 errors)
- `./vendor/bin/phpunit tests/Unit --testdox`
- `./vendor/bin/phpunit tests/Integration --testdox` (fails)


------
https://chatgpt.com/codex/tasks/task_e_68ab246c6d54832f899b531379c92f3c