### PR TITLE
Enforce auth and ownership checks for technician endpoints

### DIFF
--- a/public/api/job_checklist.php
+++ b/public/api/job_checklist.php
@@ -14,11 +14,8 @@ if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
     return;
 }
-
-if (current_role() === 'guest') {
-    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-    return;
-}
+require_auth();
+require_role('tech');
 
 $jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
 if ($jobId <= 0) {
@@ -28,6 +25,7 @@ if ($jobId <= 0) {
 
 try {
     $pdo = getPDO();
+    require_job_owner($pdo, $jobId);
     $items = JobChecklistItem::listForJob($pdo, $jobId);
     $items = array_map(
         static fn(array $it): array => [

--- a/public/api/job_notes_add.php
+++ b/public/api/job_notes_add.php
@@ -20,11 +20,8 @@ if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
     return;
 }
-
-if (current_role() === 'guest') {
-    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-    return;
-}
+require_auth();
+require_role('tech');
 
 $jobId        = isset($data['job_id']) ? (int)$data['job_id'] : 0;
 $technicianId = isset($data['technician_id']) ? (int)$data['technician_id'] : 0;
@@ -35,8 +32,15 @@ if ($jobId <= 0 || $technicianId <= 0 || $note === '') {
     return;
 }
 
+$sessionId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
+if ($sessionId !== $technicianId) {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
+    return;
+}
+
 try {
     $pdo = getPDO();
+    require_job_owner($pdo, $jobId);
     $id  = JobNote::add($pdo, $jobId, $technicianId, $note);
     $status = $pdo->query('SELECT status FROM jobs WHERE id=' . $jobId)->fetchColumn();
     JsonResponse::json(['ok' => true, 'id' => $id, 'status' => $status]);

--- a/public/api/job_notes_list.php
+++ b/public/api/job_notes_list.php
@@ -14,11 +14,8 @@ if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
     return;
 }
-
-if (current_role() === 'guest') {
-    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-    return;
-}
+require_auth();
+require_role('tech');
 
 $jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
 if ($jobId <= 0) {
@@ -28,6 +25,7 @@ if ($jobId <= 0) {
 
 try {
     $pdo   = getPDO();
+    require_job_owner($pdo, $jobId);
     $notes = JobNote::listForJob($pdo, $jobId);
     JsonResponse::json(['ok' => true, 'notes' => $notes]);
 } catch (Throwable $e) {

--- a/public/api/job_photos_list.php
+++ b/public/api/job_photos_list.php
@@ -14,11 +14,8 @@ if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
     return;
 }
-
-if (current_role() === 'guest') {
-    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-    return;
-}
+require_auth();
+require_role('tech');
 
 $jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
 if ($jobId <= 0) {
@@ -28,6 +25,7 @@ if ($jobId <= 0) {
 
 try {
     $pdo    = getPDO();
+    require_job_owner($pdo, $jobId);
     $photos = JobPhoto::listForJob($pdo, $jobId);
     JsonResponse::json(['ok' => true, 'photos' => $photos]);
 } catch (Throwable $e) {

--- a/public/api/job_photos_upload.php
+++ b/public/api/job_photos_upload.php
@@ -20,11 +20,8 @@ if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
     return;
 }
-
-if (current_role() === 'guest') {
-    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-    return;
-}
+require_auth();
+require_role('tech');
 
 $jobId        = isset($data['job_id']) ? (int)$data['job_id'] : 0;
 $technicianId = isset($data['technician_id']) ? (int)$data['technician_id'] : 0;
@@ -33,6 +30,12 @@ $files        = $_FILES['photos'] ?? null;
 
 if ($jobId <= 0 || $technicianId <= 0 || !is_array($files) || !isset($files['name'])) {
     JsonResponse::json(['ok' => false, 'error' => 'Missing parameters', 'code' => \ErrorCodes::VALIDATION_ERROR], 422);
+    return;
+}
+
+$sessionId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
+if ($sessionId !== $technicianId) {
+    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
     return;
 }
 
@@ -64,6 +67,7 @@ if (!is_dir($uploadDir)) {
 }
 
 $pdo = getPDO();
+require_job_owner($pdo, $jobId);
 $uploaded = [];
 
 for ($i = 0; $i < $count; $i++) {

--- a/public/api/job_start.php
+++ b/public/api/job_start.php
@@ -20,11 +20,8 @@ if (!verify_csrf_token($data['csrf_token'] ?? null)) {
     JsonResponse::json(['ok' => false, 'error' => 'Invalid CSRF token', 'code' => \ErrorCodes::CSRF_INVALID], 400);
     return;
 }
-
-if (current_role() === 'guest') {
-    JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-    return;
-}
+require_auth();
+require_role('tech');
 
 $jobId = isset($data['job_id']) ? (int)$data['job_id'] : 0;
 $lat   = isset($data['location_lat']) ? (float)$data['location_lat'] : (isset($data['lat']) ? (float)$data['lat'] : null);
@@ -37,59 +34,7 @@ if ($jobId <= 0 || $lat === null || $lng === null) {
 
 try {
     $pdo    = getPDO();
-    $userId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
-
-    // Verify that the logged-in technician is assigned to this job. Some
-    // deployments use a `technician_id` column on `jobs`; others use the
-    // `job_employee_assignment` join table. Detect which schema is present.
-    $hasTechColumn = false;
-    try {
-        $pdo->query('SELECT technician_id FROM jobs LIMIT 0');
-        $hasTechColumn = true;
-    } catch (Throwable $ignore) {
-        $hasTechColumn = false;
-    }
-
-    if ($hasTechColumn) {
-        $st = $pdo->prepare('SELECT technician_id FROM jobs WHERE id = :id AND deleted_at IS NULL');
-        if ($st === false) {
-            throw new RuntimeException('Failed to prepare statement');
-        }
-        $st->execute([':id' => $jobId]);
-        $techId = (int) $st->fetchColumn();
-
-        $assigned = ($techId === $userId && $techId !== 0);
-        if (!$assigned) {
-            // Fallback to join table if technician_id column doesn't match
-            try {
-                $st = $pdo->prepare('SELECT 1 FROM job_employee_assignment WHERE job_id = :jid AND employee_id = :eid LIMIT 1');
-                if ($st === false) {
-                    throw new RuntimeException('Failed to prepare assignment check');
-                }
-                $st->execute([':jid' => $jobId, ':eid' => $userId]);
-                $assigned = ($st->fetchColumn() !== false);
-            } catch (Throwable $ignore) {
-                // join table absent; leave $assigned false
-            }
-        }
-
-        if (!$assigned) {
-            JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-            return;
-        }
-    } else {
-        // Fallback: check assignment via join table
-        $st = $pdo->prepare('SELECT 1 FROM job_employee_assignment WHERE job_id = :jid AND employee_id = :eid LIMIT 1');
-        if ($st === false) {
-            throw new RuntimeException('Failed to prepare assignment check');
-        }
-        $st->execute([':jid' => $jobId, ':eid' => $userId]);
-        if ($st->fetchColumn() === false) {
-            JsonResponse::json(['ok' => false, 'error' => 'Forbidden', 'code' => \ErrorCodes::FORBIDDEN], 403);
-            return;
-        }
-    }
-
+    require_job_owner($pdo, $jobId);
     $ok = Job::start($pdo, $jobId, $lat, $lng);
     if ($ok) {
         JsonResponse::json(['ok' => true, 'status' => 'in_progress']);

--- a/public/tech_job.php
+++ b/public/tech_job.php
@@ -5,11 +5,19 @@
 declare(strict_types=1);
 
 require __DIR__ . '/_cli_guard.php';
+require __DIR__ . '/_auth.php';
 require __DIR__ . '/_csrf.php';
+require __DIR__ . '/../config/database.php';
+
+require_auth();
+require_role('tech');
+
+$jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$pdo    = getPDO();
+require_job_owner($pdo, $jobId);
 
 $csrf   = csrf_token();
 $techId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
-$jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 ?>
 <!doctype html>
 <html lang="en">

--- a/public/tech_job_complete.php
+++ b/public/tech_job_complete.php
@@ -5,11 +5,19 @@
 declare(strict_types=1);
 
 require __DIR__ . '/_cli_guard.php';
+require __DIR__ . '/_auth.php';
 require __DIR__ . '/_csrf.php';
+require __DIR__ . '/../config/database.php';
+
+require_auth();
+require_role('tech');
+
+$jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$pdo    = getPDO();
+require_job_owner($pdo, $jobId);
 
 $csrf   = csrf_token();
 $techId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;
-$jobId  = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 ?>
 <!doctype html>
 <html lang="en">

--- a/public/tech_jobs.php
+++ b/public/tech_jobs.php
@@ -5,7 +5,11 @@
 declare(strict_types=1);
 
 require __DIR__ . '/_cli_guard.php';
+require __DIR__ . '/_auth.php';
 require __DIR__ . '/_csrf.php';
+
+require_auth();
+require_role('tech');
 
 $csrf = csrf_token();
 $techId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : 0;


### PR DESCRIPTION
## Summary
- add `require_auth()` and `require_job_owner()` helpers for authentication and technician ownership
- require auth/role checks on technician API endpoints and pages
- validate technician session matches job data before allowing access or mutations

## Testing
- ❌ `vendor/bin/phpunit --stop-on-failure` (AssignmentConflictTest::testRejectsOverlappingAssignments failed)


------
https://chatgpt.com/codex/tasks/task_e_68ab2684ba4c832f9311ca306957030e