### PR TITLE
Implement role-aware navigation links

### DIFF
--- a/partials/navbar.php
+++ b/partials/navbar.php
@@ -1,19 +1,42 @@
 <?php
 // /partials/navbar.php
-// Bootstrap 5 navbar with active link highlighting
+// Bootstrap 5 navbar with role-based link visibility
 
-$current = basename($_SERVER['SCRIPT_NAME'] ?? '');
-$items = [
-    'jobs.php' => 'Jobs',
-    'employees.php' => 'Employees',
-    'customers.php' => 'Customers',
-    'assignments.php' => 'Assignments',
-    'availability_manager.php' => 'Availability',
-];
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$role    = $_SESSION['role'] ?? 'guest';
+$current = ltrim($_SERVER['SCRIPT_NAME'] ?? '', '/');
+
+$items = [];
+
+if ($role === 'admin' || $role === 'dispatcher') {
+    $items = [
+        'jobs.php' => 'Jobs',
+        'employees.php' => 'Employees',
+        'customers.php' => 'Customers',
+        'assignments.php' => 'Assignments',
+        'availability_manager.php' => 'Availability',
+    ];
+    if ($role === 'admin') {
+        $items = ['admin/index.php' => 'Admin'] + $items;
+    }
+} elseif ($role === 'tech' || $role === 'field_tech') {
+    $items = [
+        'tech_jobs.php' => "Today's Jobs",
+    ];
+}
+
+$home = match (true) {
+    $role === 'admin' || $role === 'dispatcher' => '/jobs.php',
+    $role === 'tech' || $role === 'field_tech' => '/tech_jobs.php',
+    default => '/login.php',
+};
 ?>
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
   <div class="container-fluid">
-    <a class="navbar-brand" href="/jobs.php">FieldOps</a>
+    <a class="navbar-brand" href="<?= $home ?>">FieldOps</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/public/admin/nav.php
+++ b/public/admin/nav.php
@@ -1,7 +1,15 @@
 <?php
 declare(strict_types=1);
 require_once __DIR__ . '/../_auth.php';
-require_role('admin');
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$role = $_SESSION['role'] ?? 'guest';
+if ($role !== 'admin') {
+    return;
+}
 ?>
 <nav class="mb-3">
   <a href="/admin/job_type_list.php" class="me-3">Job Types</a>


### PR DESCRIPTION
## Summary
- Read user roles from session to tailor navigation links
- Hide admin/dispatcher links from unauthorized users
- Restrict admin navigation to admin role only

## Testing
- `make unit`
- `make integration` *(fails: FOREIGN KEY constraint in AssignmentsApiTest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab28368dd4832f87df98e7fde69475