### PR TITLE
Enforce password policy and hashing with user management APIs

### DIFF
--- a/config/password_blacklist.php
+++ b/config/password_blacklist.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'password',
+    '123456',
+    '123456789',
+    '12345678',
+    'qwerty',
+    'abc123',
+    '111111',
+    '1234567',
+    'dragon',
+];

--- a/public/api/change_password.php
+++ b/public/api/change_password.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/User.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    http_response_code(405);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Method not allowed'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$userId = isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : 0;
+if ($userId <= 0) {
+    http_response_code(401);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Unauthorized'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+$raw  = file_get_contents('php://input');
+$data = $_POST;
+if ($data === [] && is_string($raw) && $raw !== '') {
+    $json = json_decode($raw, true);
+    if (is_array($json)) {
+        $data = $json;
+    }
+}
+
+$password = isset($data['password']) && is_string($data['password']) ? $data['password'] : '';
+if ($password === '') {
+    http_response_code(400);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Missing password'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $res = User::updatePassword($pdo, $userId, $password);
+    if (!$res['ok']) {
+        http_response_code(400);
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode(['ok' => false, 'error' => $res['error'] ?? 'Invalid password'], JSON_UNESCAPED_SLASHES);
+        return;
+    }
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => true], JSON_UNESCAPED_SLASHES);
+} catch (Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Server error'], JSON_UNESCAPED_SLASHES);
+}

--- a/public/api/register.php
+++ b/public/api/register.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/User.php';
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    http_response_code(405);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Method not allowed'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+$raw  = file_get_contents('php://input');
+$data = $_POST;
+if ($data === [] && is_string($raw) && $raw !== '') {
+    $json = json_decode($raw, true);
+    if (is_array($json)) {
+        $data = $json;
+    }
+}
+
+$username = isset($data['username']) && is_string($data['username']) ? trim($data['username']) : '';
+$email    = isset($data['email']) && is_string($data['email']) ? trim($data['email']) : '';
+$password = isset($data['password']) && is_string($data['password']) ? $data['password'] : '';
+
+if ($username === '' || $email === '' || $password === '') {
+    http_response_code(400);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Missing fields'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $res = User::create($pdo, $username, $email, $password);
+    if (!$res['ok']) {
+        http_response_code(400);
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode(['ok' => false, 'error' => $res['error'] ?? 'Invalid password'], JSON_UNESCAPED_SLASHES);
+        return;
+    }
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => true, 'id' => $res['id'] ?? 0], JSON_UNESCAPED_SLASHES);
+} catch (Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Server error'], JSON_UNESCAPED_SLASHES);
+}


### PR DESCRIPTION
## Summary
- add password policy validation and hashing to `User` model
- create registration and password change API endpoints
- blacklist common passwords to prevent weak credentials

## Testing
- `make lint` *(fails: Function require_auth not found, etc.)*
- `make test` *(fails: integration tests aborted with F markers)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2a0a5dd0832fa493d082d8289edf