### PR TITLE
Log auth events to audit trail

### DIFF
--- a/public/api/change_password.php
+++ b/public/api/change_password.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 require __DIR__ . '/../_cli_guard.php';
 require_once __DIR__ . '/../../config/database.php';
 require_once __DIR__ . '/../../models/User.php';
+require_once __DIR__ . '/../../models/AuditLog.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {
@@ -50,6 +51,11 @@ try {
         header('Content-Type: application/json; charset=utf-8');
         echo json_encode(['ok' => false, 'error' => $res['error'] ?? 'Invalid password'], JSON_UNESCAPED_SLASHES);
         return;
+    }
+    try {
+        AuditLog::insert($pdo, $userId, 'password_reset', ['ip' => $_SERVER['REMOTE_ADDR'] ?? '']);
+    } catch (Throwable) {
+        // ignore
     }
     header('Content-Type: application/json; charset=utf-8');
     echo json_encode(['ok' => true], JSON_UNESCAPED_SLASHES);

--- a/public/api/logout.php
+++ b/public/api/logout.php
@@ -2,9 +2,20 @@
 declare(strict_types=1);
 
 require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../../models/AuditLog.php';
 
 if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
+}
+
+$userId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : (isset($_SESSION['user_id']) ? (int)$_SESSION['user_id'] : null);
+$ip     = $_SERVER['REMOTE_ADDR'] ?? '';
+try {
+    $pdo = getPDO();
+    AuditLog::insert($pdo, $userId, 'logout', ['ip' => $ip]);
+} catch (Throwable) {
+    // ignore
 }
 
 $_SESSION = [];

--- a/tests/Integration/AuthEndpointsAuditTest.php
+++ b/tests/Integration/AuthEndpointsAuditTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../support/TestPdo.php';
+require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+require_once __DIR__ . '/../../models/User.php';
+
+final class AuthEndpointsAuditTest extends TestCase
+{
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $this->pdo = createTestPdo();
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->exec('CREATE TABLE IF NOT EXISTS audit_log (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INT NULL, action TEXT NOT NULL, details TEXT NULL, created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)');
+        $this->pdo->exec('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT, email TEXT, password TEXT, role TEXT, last_login DATETIME NULL)');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function testAuditLogsForAuthEndpoints(): void
+    {
+        $username = 'auuser';
+        $email    = 'au@example.com';
+        $pass     = 'Secret123';
+        $res = User::create($this->pdo, $username, $email, $pass);
+        $uid = (int)($res['id'] ?? 0);
+
+        // Successful login
+        EndpointHarness::run(__DIR__ . '/../../public/api/login.php', [
+            'username' => $username,
+            'password' => $pass,
+        ], [], 'POST', ['json' => true, 'inject_csrf' => false]);
+
+        // Failed login
+        EndpointHarness::run(__DIR__ . '/../../public/api/login.php', [
+            'username' => $username,
+            'password' => 'badpass',
+        ], [], 'POST', ['json' => true, 'inject_csrf' => false]);
+
+        // Logout
+        EndpointHarness::run(__DIR__ . '/../../public/api/logout.php', [], [
+            'user_id' => $uid,
+            'user' => ['id' => $uid],
+        ], 'POST', ['inject_csrf' => false]);
+
+        // Password reset
+        EndpointHarness::run(__DIR__ . '/../../public/api/change_password.php', [
+            'password' => 'NewPass123',
+        ], [
+            'user_id' => $uid,
+        ], 'POST', ['json' => true, 'inject_csrf' => false]);
+
+        $rows = $this->pdo->query('SELECT action FROM audit_log ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertContains('login_success', $rows);
+        $this->assertContains('login_failure', $rows);
+        $this->assertContains('logout', $rows);
+        $this->assertContains('password_reset', $rows);
+    }
+}


### PR DESCRIPTION
## Summary
- log login success and failure events, capturing identifier and IP
- record logout and password reset actions with user ID and IP
- test audit logging across authentication endpoints

## Testing
- `FIELDOPS_TEST_DSN=sqlite:/tmp/fieldops_test.db APP_ENV=test ./vendor/bin/phpunit tests/Integration/AuthEndpointsAuditTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab2c8f2ab0832f8d93657843d81ec0