### PR TITLE
Remove transactions from test DB migration script

### DIFF
--- a/scripts/migrate_test_db.php
+++ b/scripts/migrate_test_db.php
@@ -45,22 +45,15 @@ function migrateTestDb(PDO $pdo): void
         }
 
         try {
-            $pdo->beginTransaction();
             $pdo->exec($sql);
             $stmt = $pdo->prepare('INSERT INTO migrations (filename) VALUES (?)');
             $stmt->execute([$name]);
-            $pdo->commit();
             echo "Applied migration: {$name}\n";
         } catch (PDOException $e) {
-            if ($pdo->inTransaction()) {
-                $pdo->rollBack();
-            }
             if ($e->getCode() === '42S01') {
                 // Table already exists; mark migration as applied for idempotency
-                $pdo->beginTransaction();
                 $stmt = $pdo->prepare('INSERT INTO migrations (filename) VALUES (?)');
                 $stmt->execute([$name]);
-                $pdo->commit();
                 echo "Skipped migration (table exists): {$name}\n";
                 continue;
             }


### PR DESCRIPTION
## Summary
- simplify migrate_test_db by removing transaction handling and rollback logic

## Testing
- `php -l scripts/migrate_test_db.php`
- `./vendor/bin/phpunit --teamcity` *(fails: AssignmentsApiTest::testAssignEmployeesSuccess, AssignmentsApiTest::testAssignEmployeesInvalidJobId, AssignmentsApiTest::testReplaceAssignmentsForAJob, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a85e390832fa66862a9cf13002d