### PR TITLE
Ensure users migration runs before others in test DB

### DIFF
--- a/scripts/migrate_test_db.php
+++ b/scripts/migrate_test_db.php
@@ -31,6 +31,13 @@ function migrateTestDb(PDO $pdo): void
     $files = glob($dir . '/*.sql') ?: [];
     sort($files);
 
+    $usersMigration = $dir . '/20241004185000_create_users.sql';
+    $usersIndex = array_search($usersMigration, $files, true);
+    if ($usersIndex !== false) {
+        unset($files[$usersIndex]);
+        array_unshift($files, $usersMigration);
+    }
+
     foreach ($files as $file) {
         $name = basename($file);
         $stmt = $pdo->prepare('SELECT 1 FROM migrations WHERE filename = ?');


### PR DESCRIPTION
## Summary
- Ensure `20241004185000_create_users.sql` runs first when migrating the test database

## Testing
- `php -l scripts/migrate_test_db.php`
- `vendor/bin/phpunit` *(fails: FF..FFFF)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4ecfb934832f91b7512abf8cebe8