### PR TITLE
Guard migration scripts from nested transactions

### DIFF
--- a/bin/cleanup_orphans.php
+++ b/bin/cleanup_orphans.php
@@ -19,7 +19,9 @@ $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 function out(string $m): void { echo $m, PHP_EOL; }
 
-$pdo->beginTransaction();
+if (!$pdo->inTransaction()) {
+    $pdo->beginTransaction();
+}
 
 try {
     // 1) employee_skills → employees
@@ -67,10 +69,14 @@ try {
     ");
     out("[OK] jobtype_skills deleted (no skill): " . (int)$n5);
 
-    $pdo->commit();
+    if ($pdo->inTransaction()) {
+        $pdo->commit();
+    }
     out("Done.");
 } catch (Throwable $e) {
-    if ($pdo->inTransaction()) $pdo->rollBack();
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
     fwrite(STDERR, "[ERR] ".$e->getMessage().PHP_EOL);
     exit(1);
 }

--- a/bin/ensure_constraints.php
+++ b/bin/ensure_constraints.php
@@ -59,7 +59,9 @@ function fkInfo(PDO $pdo, string $table, string $column): array {
     return $st->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$pdo->beginTransaction();
+if (!$pdo->inTransaction()) {
+    $pdo->beginTransaction();
+}
 
 try {
     // 1) job_employee_assignment UNIQUE(job_id, employee_id)
@@ -130,10 +132,14 @@ try {
         out('[ea] UNIQUE availability window already present.');
     }
 
-    $pdo->commit();
+    if ($pdo->inTransaction()) {
+        $pdo->commit();
+    }
     out('Done. All constraints ensured.');
 } catch (Throwable $e) {
-    if ($pdo->inTransaction()) $pdo->rollBack();
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
     fwrite(STDERR, "[ERROR] " . $e->getMessage() . PHP_EOL);
     exit(1);
 }

--- a/tests/test_no_conflict_eligibility.php
+++ b/tests/test_no_conflict_eligibility.php
@@ -159,7 +159,9 @@ try {
     out("OK: No conflict reported for employee #{$employeeId} (job #{$jobId}, {$scheduledDate} {$scheduledTime}).");
 
     // Roll back to leave DB clean
-    $pdo->rollBack();
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
     exit(0);
 
 } catch (Throwable $e) {


### PR DESCRIPTION
## Summary
- Guard transactional commit/rollback in cleanup and constraint scripts with `PDO::inTransaction()` checks
- Conditionally start transactions only when needed
- Safely roll back in `test_no_conflict_eligibility` only when a transaction is active

## Testing
- `php -l bin/cleanup_orphans.php`
- `php -l bin/ensure_constraints.php`
- `php -l tests/test_no_conflict_eligibility.php`
- `vendor/bin/phpunit --stop-on-failure` *(fails: AssignmentConflictTest::testRejectsOverlappingAssignments)*

------
https://chatgpt.com/codex/tasks/task_e_68ab71517104832fade13e5d192dcbc4