### PR TITLE
feat: support test DB credentials for custom DSNs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,10 @@ configure a database and seed it with minimal data so an active employee exists.
    ];
    ```
 
+   For tests that specify a non-SQLite DSN using `FIELDOPS_TEST_DSN`, you can
+   provide dedicated credentials via `FIELDOPS_TEST_USER` and
+   `FIELDOPS_TEST_PASS`. These fall back to `DB_USER` / `DB_PASS` when unset.
+
 2. **Create the database schema**:
 
    ```bash


### PR DESCRIPTION
## Summary
- detect non-SQLite test DSNs and read credentials from `FIELDOPS_TEST_USER` / `FIELDOPS_TEST_PASS`
- document new optional env vars for tests

## Testing
- `vendor/bin/phpunit tests/Unit/SqliteSchemaTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68ab834acc6c832f90df26e05e2bf0f2