### PR TITLE
Respect APP_ENV for session cookie security

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ When running integration tests (`APP_ENV=test`), optional credentials can be
 placed in `config/test.env.php`. This keeps test database settings isolated
 from your local development configuration.
 
+## Session Cookies
+
+Session cookies are marked `secure` in all environments except `dev` so that
+local development can run without HTTPS. Set the `SESSION_SECURE` environment
+variable to override this behavior.
+
 ## CDN Scripts
 
 When including scripts from a CDN, always add an `integrity` hash and

--- a/helpers/session.php
+++ b/helpers/session.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 // Session bootstrap for FieldOps
 // Sets secure cookie parameters and enforces inactivity/absolute timeouts.
 
+$appEnv = getenv('APP_ENV') ?: 'dev';
+$sessionSecure = getenv('SESSION_SECURE');
+$secure = ($sessionSecure !== false)
+    ? filter_var($sessionSecure, FILTER_VALIDATE_BOOLEAN)
+    : ($appEnv !== 'dev');
+
 $cookieParams = [
     'httponly' => true,
-    'secure' => true,
+    'secure' => $secure,
     'samesite' => 'Strict',
 ];
 


### PR DESCRIPTION
## Summary
- Toggle session cookie `secure` attribute based on APP_ENV or SESSION_SECURE
- Document session cookie behavior in README

## Testing
- `make lint` *(fails: 371 errors)*
- `make test` *(fails: integration tests reported failing cases)*

------
https://chatgpt.com/codex/tasks/task_e_68ab833af85c832fa0dac304e361a070