### PR TITLE
Skip Sqlite schema test unless SQLite

### DIFF
--- a/tests/Unit/SqliteSchemaTest.php
+++ b/tests/Unit/SqliteSchemaTest.php
@@ -7,7 +7,15 @@ final class SqliteSchemaTest extends TestCase
 {
     public function testSchemaIncludesExpectedTablesAndColumns(): void
     {
+        $dsn = getenv('FIELDOPS_TEST_DSN');
+        if ($dsn !== false && strncmp((string) $dsn, 'sqlite', 6) !== 0) {
+            $this->markTestSkipped('Sqlite schema test runs only with SQLite');
+        }
+
         $pdo = createTestPdo();
+        if ($pdo->getAttribute(PDO::ATTR_DRIVER_NAME) !== 'sqlite') {
+            $this->markTestSkipped('Sqlite schema test runs only with SQLite');
+        }
 
         $tables = $pdo->query("SELECT name FROM sqlite_master WHERE type='table'")->fetchAll(PDO::FETCH_COLUMN);
         $this->assertContains('job_types', $tables);


### PR DESCRIPTION
## Summary
- Skip SqliteSchemaTest when FIELDOPS_TEST_DSN or PDO driver is not sqlite

## Testing
- `vendor/bin/phpunit tests/Unit/SqliteSchemaTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab905a364c832f86851b89b5428210