### PR TITLE
Extract authentication helper and tests

### DIFF
--- a/public/api/login.php
+++ b/public/api/login.php
@@ -2,9 +2,7 @@
 declare(strict_types=1);
 
 require __DIR__ . '/../_cli_guard.php';
-require_once __DIR__ . '/../../config/database.php';
-require_once __DIR__ . '/../../models/User.php';
-require_once __DIR__ . '/../../models/AuditLog.php';
+require_once __DIR__ . '/../../helpers/auth_helpers.php';
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 if ($method !== 'POST') {
@@ -40,23 +38,16 @@ if ($identifier === '' || $password === '') {
 
 try {
     $pdo  = getPDO();
-    $user = User::findByIdentifier($pdo, $identifier);
-    if ($user === null || !password_verify($password, (string)$user['password'])) {
-        http_response_code(401);
+    $result = authenticate($pdo, $identifier, $password);
+    if (!$result['ok']) {
+        $status = ($result['error'] === 'Invalid credentials') ? 401 : 500;
+        http_response_code($status);
         header('Content-Type: application/json; charset=utf-8');
-        echo json_encode(['ok' => false, 'error' => 'Invalid credentials'], JSON_UNESCAPED_SLASHES);
-        try {
-            $uid = $user['id'] ?? null;
-            AuditLog::insert($pdo, $uid ? (int)$uid : null, 'login_failure', [
-                'identifier' => $identifier,
-                'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
-            ]);
-        } catch (Throwable) {
-            // ignore
-        }
+        echo json_encode(['ok' => false, 'error' => $result['error']], JSON_UNESCAPED_SLASHES);
         return;
     }
 
+    $user = $result['user'];
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }
@@ -66,17 +57,6 @@ try {
     $_SESSION['user_id'] = $id;
     $_SESSION['role']    = $role;
     $_SESSION['user']    = ['id' => $id, 'role' => $role];
-
-    User::updateLastLogin($pdo, $id);
-
-    try {
-        AuditLog::insert($pdo, $id, 'login_success', [
-            'identifier' => $identifier,
-            'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
-        ]);
-    } catch (Throwable) {
-        // ignore
-    }
 
     header('Content-Type: application/json; charset=utf-8');
     echo json_encode(['ok' => true, 'role' => $role], JSON_UNESCAPED_SLASHES);

--- a/tests/Unit/AuthenticateHelperTest.php
+++ b/tests/Unit/AuthenticateHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../helpers/auth_helpers.php';
+require_once __DIR__ . '/../support/TestPdo.php';
+
+final class AuthenticateHelperTest extends TestCase
+{
+    private function createPdo(): PDO
+    {
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        seedSqliteSchema($pdo);
+        return $pdo;
+    }
+
+    public function testAuthenticateSuccess(): void
+    {
+        $pdo = $this->createPdo();
+        $hash = password_hash('Passw0rd1', PASSWORD_BCRYPT);
+        $pdo->exec("INSERT INTO users (username, email, password, role) VALUES ('alice','alice@example.com','$hash','dispatcher')");
+
+        $res = authenticate($pdo, 'alice', 'Passw0rd1');
+        $this->assertTrue($res['ok']);
+        $this->assertIsArray($res['user']);
+        $this->assertNull($res['error']);
+
+        $count = (int)$pdo->query("SELECT COUNT(*) FROM audit_log WHERE action = 'login_success'")->fetchColumn();
+        $this->assertSame(1, $count);
+    }
+
+    public function testAuthenticateFailure(): void
+    {
+        $pdo = $this->createPdo();
+        $hash = password_hash('Passw0rd1', PASSWORD_BCRYPT);
+        $pdo->exec("INSERT INTO users (username, email, password, role) VALUES ('bob','bob@example.com','$hash','dispatcher')");
+
+        $res = authenticate($pdo, 'bob', 'wrong');
+        $this->assertFalse($res['ok']);
+        $this->assertNull($res['user']);
+        $this->assertSame('Invalid credentials', $res['error']);
+        $count = (int)$pdo->query("SELECT COUNT(*) FROM audit_log WHERE action = 'login_failure'")->fetchColumn();
+        $this->assertSame(1, $count);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize login authentication in `authenticate()` helper
- simplify API login endpoint to use helper
- add unit tests for authentication logic

## Testing
- `make lint` *(fails: Found 373 errors)*
- `make unit` *(fails: JobsCompletedFilterTest, JobsDateFilterTest)*
- `./vendor/bin/phpunit tests/Unit/AuthenticateHelperTest.php --testdox`
- `./vendor/bin/phpunit tests/Integration/AuthEndpointsAuditTest.php --testdox`
- `./vendor/bin/phpunit tests/Integration/LoginValidationTest.php --testdox`
- `./vendor/bin/phpunit tests/Integration/UserEndpointsTest.php --testdox`


------
https://chatgpt.com/codex/tasks/task_e_68ab918a2e58832f9c61be498e888244