### PR TITLE
Include show_past when filtering completed jobs

### DIFF
--- a/tests/Unit/JobsCompletedFilterTest.php
+++ b/tests/Unit/JobsCompletedFilterTest.php
@@ -43,7 +43,7 @@ final class JobsCompletedFilterTest extends TestCase
         }
         $GLOBALS['__FIELDOPS_TEST_CALL__'] = true;
 
-        $_GET = ['status' => 'completed'];
+        $_GET = ['status' => 'completed', 'show_past' => '1'];
         ob_start();
         require __DIR__ . '/../../public/api/jobs.php';
         $output = ob_get_clean();


### PR DESCRIPTION
## Summary
- ensure completed job requests include `show_past` to show previously completed jobs

## Testing
- `vendor/bin/phpunit tests/Unit/JobsCompletedFilterTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab93ba5b94832f814c7dfe996be3d1