### PR TITLE
Remove unused variable in login API

### DIFF
--- a/public/api/login.php
+++ b/public/api/login.php
@@ -59,8 +59,6 @@ try {
         return json_out(['ok' => false, 'error' => 'Invalid credentials'], 401);
 
     }
-
-    $user = $result['user'];
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }


### PR DESCRIPTION
## Summary
- remove unused $result variable in login API, rely on User::findByIdentifier return value

## Testing
- `./vendor/bin/phpunit tests/Integration/LoginValidationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68aba63a8834832f962fae81ac88a693