### PR TITLE
Add Playwright login flow test

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -8,7 +8,7 @@ module.exports = defineConfig({
   },
   webServer: {
     command: 'php -S 127.0.0.1:8000 -t public',
-    url: 'http://127.0.0.1:8000',
+    url: 'http://127.0.0.1:8000/login.php',
     reuseExistingServer: !process.env.CI,
     env: {
       DB_HOST: process.env.DB_HOST || '127.0.0.1',

--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -1,0 +1,31 @@
+const { test, expect } = require('@playwright/test');
+
+const creds = { username: '', password: 'Passw0rd1' };
+
+test.beforeAll(async ({ request }) => {
+  const uname = `testuser_${Date.now()}`;
+  creds.username = uname;
+  await request.post('/api/register.php', {
+    form: {
+      username: uname,
+      email: `${uname}@example.com`,
+      password: creds.password,
+    },
+  });
+});
+
+test('redirects to jobs on successful login', async ({ page }) => {
+  await page.goto('/login.php');
+  await page.fill('#username', creds.username);
+  await page.fill('#password', creds.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL('**/jobs.php');
+});
+
+test('shows error on invalid credentials', async ({ page }) => {
+  await page.goto('/login.php');
+  await page.fill('#username', creds.username);
+  await page.fill('#password', 'wrongpass');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('#login-error')).toHaveText(/Invalid credentials/i);
+});


### PR DESCRIPTION
## Summary
- add Playwright login UI test covering success and failure cases
- point Playwright webServer URL at login page for reliable startup

## Testing
- `npx playwright test tests/ui/login.spec.js` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*


------
https://chatgpt.com/codex/tasks/task_e_68aba8ece630832fa94e6bd012d552da