### PR TITLE
test: improve login flow verification

### DIFF
--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -14,12 +14,28 @@ test.beforeAll(async ({ request }) => {
   });
 });
 
-test('redirects to jobs on successful login', async ({ page }) => {
+test('redirects to jobs on successful login', async ({ page, context }) => {
   await page.goto('/login.php');
   await page.fill('#username', creds.username);
   await page.fill('#password', creds.password);
+
   await page.click('button[type="submit"]');
-  await page.waitForURL('**/jobs.php');
+  let response = await page.waitForResponse('/api/login.php');
+
+  if ([401, 422].includes(response.status())) {
+    await expect(page.locator('input[name="csrf_token"][type="hidden"]')).toHaveCount(1);
+    const cookies = await context.cookies();
+    const sessionCookie = cookies.find(c => c.name === 'PHPSESSID');
+    expect(sessionCookie).toBeTruthy();
+
+    await page.click('button[type="submit"]');
+    response = await page.waitForResponse('/api/login.php');
+  }
+
+  expect(response.status()).toBe(200);
+  const json = await response.json();
+  expect(json).toEqual({ ok: true });
+  await expect(page).toHaveURL(/\/jobs\.php$/);
 });
 
 test('shows error on invalid credentials', async ({ page }) => {


### PR DESCRIPTION
## Summary
- handle potential CSRF handshake during login
- verify login API response and redirect

## Testing
- `npm run test:ui tests/ui/login.spec.js` *(fails: browser executable doesn't exist)*
- `npx playwright install chromium` *(fails: download failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abad458cf4832f825b8cc1f747fb8b