### PR TITLE
Ensure login flow persists users and validates session

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,7 +16,8 @@ module.exports = defineConfig({
       DB_NAME: process.env.DB_NAME || 'fieldops_integration',
       DB_USER: process.env.DB_USER || 'root',
       DB_PASS: process.env.DB_PASS || '1234!@#$',
-      APP_ENV: 'dev'
+      APP_ENV: 'test',
+      FIELDOPS_TEST_DSN: process.env.FIELDOPS_TEST_DSN || 'sqlite:/tmp/fieldops_test.db'
     }
   }
 });

--- a/public/api/test_user_lookup.php
+++ b/public/api/test_user_lookup.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../_cli_guard.php';
+require_once __DIR__ . '/../../config/database.php';
+
+if (getenv('APP_ENV') !== 'test') {
+    http_response_code(403);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Forbidden'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+$username = isset($_GET['username']) && is_string($_GET['username']) ? trim($_GET['username']) : '';
+if ($username === '') {
+    http_response_code(400);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Missing username'], JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+try {
+    $pdo = getPDO();
+    $st  = $pdo->prepare('SELECT id, username, email FROM users WHERE username = :u LIMIT 1');
+    if ($st === false) {
+        throw new RuntimeException('Prepare failed');
+    }
+    $st->execute([':u' => $username]);
+    $row = $st->fetch(PDO::FETCH_ASSOC);
+    if ($row === false) {
+        http_response_code(404);
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode(['ok' => false, 'error' => 'Not found'], JSON_UNESCAPED_SLASHES);
+        return;
+    }
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => true, 'user' => $row], JSON_UNESCAPED_SLASHES);
+} catch (Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode(['ok' => false, 'error' => 'Server error'], JSON_UNESCAPED_SLASHES);
+}

--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -12,25 +12,22 @@ test.beforeAll(async ({ request }) => {
       password: creds.password,
     },
   });
+  const check = await request.get(`/api/test_user_lookup.php?username=${uname}`);
+  const data = await check.json();
+  expect(data.ok).toBeTruthy();
 });
 
 test('redirects to jobs on successful login', async ({ page, context }) => {
   await page.goto('/login.php');
+  await expect(page.locator('input[name="csrf_token"][type="hidden"]')).toHaveCount(1);
+  const cookies = await context.cookies();
+  const sessionCookie = cookies.find(c => c.name === 'PHPSESSID');
+  expect(sessionCookie).toBeTruthy();
+
   await page.fill('#username', creds.username);
   await page.fill('#password', creds.password);
-
   await page.click('button[type="submit"]');
-  let response = await page.waitForResponse('/api/login.php');
-
-  if ([401, 422].includes(response.status())) {
-    await expect(page.locator('input[name="csrf_token"][type="hidden"]')).toHaveCount(1);
-    const cookies = await context.cookies();
-    const sessionCookie = cookies.find(c => c.name === 'PHPSESSID');
-    expect(sessionCookie).toBeTruthy();
-
-    await page.click('button[type="submit"]');
-    response = await page.waitForResponse('/api/login.php');
-  }
+  const response = await page.waitForResponse('/api/login.php');
 
   expect(response.status()).toBe(200);
   const json = await response.json();


### PR DESCRIPTION
## Summary
- configure Playwright server to use a SQLite test database and test environment
- assert CSRF token and session cookie in login UI test and verify registration persists by lookup
- add test-only endpoint to fetch a user for verification

## Testing
- `npm run test:ui -- tests/ui/login.spec.js` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1325498832f892c1852b1c46026