### PR TITLE
Handle login response before navigation in UI test

### DIFF
--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -26,11 +26,11 @@ test('redirects to jobs on successful login', async ({ page, context }) => {
 
   await page.fill('#username', creds.username);
   await page.fill('#password', creds.password);
-  const [response] = await Promise.all([
-    page.waitForResponse('**/api/login.php'),
-    page.click('button[type="submit"]'),
-  ]);
-  const json = await response.json();
+  const jsonPromise = page
+    .waitForResponse('**/api/login.php')
+    .then(res => res.json());
+  await page.click('button[type="submit"]');
+  const json = await jsonPromise;
   expect(json).toEqual(expect.objectContaining({ ok: true, role: 'user' }));
   await expect(page).toHaveURL('/jobs.php');
 });


### PR DESCRIPTION
## Summary
- Ensure login UI test waits for `api/login.php` response and captures JSON before navigation

## Testing
- `npm run test:ui tests/ui/login.spec.js` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68abb6bc91e8832fa435e54c6cba269d