### PR TITLE
Start waiting for login response before form submit

### DIFF
--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -23,10 +23,9 @@ test('redirects to jobs on successful login', async ({ page }) => {
 
   await page.fill('#username', creds.username);
   await page.fill('#password', creds.password);
-  const [response] = await Promise.all([
-    page.waitForResponse('**/api/login.php'),
-    page.click('button[type="submit"]'),
-  ]);
+  const waitResponse = page.waitForResponse('**/api/login.php');
+  await page.click('button[type="submit"]');
+  const response = await waitResponse;
   const json = await response.json();
   expect(json).toEqual(expect.objectContaining({ ok: true, role: 'user' }));
   await expect(page).toHaveURL('/jobs.php');


### PR DESCRIPTION
## Summary
- Update login UI test to wait for `/api/login.php` response before clicking submit
- Parse response JSON prior to asserting redirect to `/jobs.php`

## Testing
- `npm run test:ui tests/ui/login.spec.js` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6802b59c832f973d049a3137ad60