### PR TITLE
Fix job filter date range and login response output

### DIFF
--- a/public/api/jobs.php
+++ b/public/api/jobs.php
@@ -37,13 +37,18 @@ try {
     if ($onlyCompleted) {
         $showPast = true; // Automatically show past jobs when only completed is requested
     }
+    if ($showPast && !isset($_GET['start'])) {
+        // When showing past jobs without an explicit start date, default
+        // to a very early date so completed jobs in the past are included.
+        $start = '1970-01-01';
+    }
     $where = ['j.deleted_at IS NULL'];
     $args = [];
     if (!$onlyCompleted) {
         if (!$showPast && $start < $today) {
             $start = $today;
         }
-        $where[] = 'DATE(j.scheduled_date) BETWEEN :start_date AND :end_date';
+        $where[] = 'j.scheduled_date BETWEEN :start_date AND :end_date';
         $args[':start_date'] = $start;
         $args[':end_date'] = $end;
     }

--- a/public/api/login.php
+++ b/public/api/login.php
@@ -81,8 +81,8 @@ try {
         // ignore
     }
 
-    json_out(['ok' => true, 'role' => $role]);
+    return json_out(['ok' => true, 'role' => $role]);
 
 } catch (Throwable $e) {
-    json_out(['ok' => false, 'error' => 'Server error'], 500);
+    return json_out(['ok' => false, 'error' => 'Server error'], 500);
 }


### PR DESCRIPTION
## Summary
- include past jobs automatically when `show_past` is set and simplify date filter
- ensure login API always returns a JSON body

## Testing
- `php -d detect_unicode=0 vendor/bin/phpunit tests/Unit/JobsCompletedFilterTest.php tests/Unit/JobsDateFilterTest.php tests/Integration/LoginValidationTest.php`
- `npx playwright test tests/ui/login.spec.js` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a5f5bec832f81c2b61f76ae3913