### PR TITLE
Ensure login endpoint returns structured JSON

### DIFF
--- a/public/api/login.php
+++ b/public/api/login.php
@@ -56,7 +56,10 @@ try {
         } catch (Throwable) {
             // ignore
         }
-        return json_out(['ok' => false, 'error' => 'Invalid credentials'], 401);
+        return json_out([
+            'ok' => false,
+            'message' => 'Invalid credentials',
+        ], 401);
 
     }
     if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -81,7 +84,11 @@ try {
         // ignore
     }
 
-    return json_out(['ok' => true, 'role' => $role]);
+    return json_out([
+        'ok' => true,
+        'role' => $role,
+        'message' => 'Login successful',
+    ]);
 
 } catch (Throwable $e) {
     return json_out(['ok' => false, 'error' => 'Server error'], 500);


### PR DESCRIPTION
## Summary
- Include user-facing message in login API responses
- Return explicit JSON success payload with ok, role, and message
- Provide message for invalid credentials with 401 status

## Testing
- `php -l public/api/login.php`
- `npm run test:ui tests/ui/login.spec.js` *(fails: browserType.launch: Executable doesn't exist; requires `npx playwright install` which fails to download Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c54a328832f8ff17d3e42ab758e