### PR TITLE
Ensure login endpoint returns structured JSON

### DIFF
--- a/public/api/login.php
+++ b/public/api/login.php
@@ -56,7 +56,10 @@ try {
         } catch (Throwable) {
             // ignore
         }
-        return json_out(['ok' => false, 'error' => 'Invalid credentials'], 401);
+        return json_out([
+            'ok' => false,
+            'message' => 'Invalid credentials',
+        ], 401);
 
     }
     if (session_status() !== PHP_SESSION_ACTIVE) {
@@ -81,7 +84,11 @@ try {
         // ignore
     }
 
-    return json_out(['ok' => true, 'role' => $role]);
+    return json_out([
+        'ok' => true,
+        'role' => $role,
+        'message' => 'Login successful',
+    ]);
 
 } catch (Throwable $e) {
     return json_out(['ok' => false, 'error' => 'Server error'], 500);

--- a/public/login.php
+++ b/public/login.php
@@ -64,7 +64,9 @@ $pageScripts = <<<HTML
         else if(data.role === 'field_tech'){ dest = '/tech_jobs.php'; }
         window.location.href = dest;
       } else {
-        err.textContent = (data && data.error) ? data.error : 'Invalid credentials';
+        err.textContent = (data && (data.message || data.error))
+          ? (data.message || data.error)
+          : 'Invalid credentials';
         err.classList.remove('d-none');
       }
     } catch(e) {


### PR DESCRIPTION
## Summary
- Include user-facing message in login API responses
- Return explicit JSON success payload with ok, role, and message
- Provide message for invalid credentials with 401 status
- Surface API-provided error message on login page

## Testing
- `php -l public/login.php`
- `php -l public/api/login.php`
- `npx playwright install` *(fails: server returned code 403 when downloading Chromium)*
- `npm run test:ui tests/ui/login.spec.js` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6c54a328832f8ff17d3e42ab758e