### PR TITLE
test: login test response concurrent

### DIFF
--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -23,9 +23,10 @@ test('redirects to jobs on successful login', async ({ page }) => {
 
   await page.fill('#username', creds.username);
   await page.fill('#password', creds.password);
-  const waitResponse = page.waitForResponse('**/api/login.php');
-  await page.click('button[type="submit"]');
-  const response = await waitResponse;
+  const [response] = await Promise.all([
+    page.waitForResponse('**/api/login.php'),
+    page.click('button[type="submit"]'),
+  ]);
   const json = await response.json();
   expect(json).toEqual(expect.objectContaining({ ok: true, role: 'user' }));
   await expect(page).toHaveURL('/jobs.php');


### PR DESCRIPTION
## Summary
- wrap login click and response wait in `Promise.all`

## Testing
- `npm run test:ui tests/ui/login.spec.js` *(fails: Executable doesn't exist for browser; attempted `npx playwright install` but download returned HTTP 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67bf7c08832fa06c5e394e085517