### PR TITLE
test: simplify login redirect check

### DIFF
--- a/tests/ui/login.spec.js
+++ b/tests/ui/login.spec.js
@@ -23,12 +23,10 @@ test('redirects to jobs on successful login', async ({ page }) => {
 
   await page.fill('#username', creds.username);
   await page.fill('#password', creds.password);
-  const [response] = await Promise.all([
-    page.waitForResponse('**/api/login.php'),
+  await Promise.all([
+    page.waitForURL('/jobs.php'),
     page.click('button[type="submit"]'),
   ]);
-  const json = await response.json();
-  expect(json).toEqual(expect.objectContaining({ ok: true, role: 'user' }));
   await expect(page).toHaveURL('/jobs.php');
 });
 


### PR DESCRIPTION
## Summary
- simplify login redirect test by waiting for navigation instead of inspecting response JSON

## Testing
- `npx playwright test tests/ui/login.spec.js` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7362c480832f82b0f1b634adb02a