### PR TITLE
Add login debug logging

### DIFF
--- a/docs/login_debug_log.md
+++ b/docs/login_debug_log.md
@@ -1,0 +1,5 @@
+# Login Debug Log
+
+The login API writes debug information to `logs/login_debug.log`. Each entry includes the identifier, client IP, whether the CSRF token was valid, and if a matching user was found. Passwords are redacted.
+
+Check this file when troubleshooting login issues.

--- a/logs/login_debug.log
+++ b/logs/login_debug.log
@@ -1,0 +1,9 @@
+Array
+(
+    [identifier] => auuser
+    [ip] => 
+    [csrf_valid] => 1
+    [user_found] => 1
+    [password] => [redacted]
+    [error] => invalid_credentials
+)


### PR DESCRIPTION
## Summary
- add detailed error logging in `public/api/login.php` for method, CSRF, missing fields, invalid credentials, and exceptions
- store entries in `logs/login_debug.log` with identifier, client IP, CSRF result, and user existence
- document debug log location for developers

## Testing
- `php -l public/api/login.php`
- `vendor/bin/phpunit` *(fails: Cannot redeclare function has_start_date())*

------
https://chatgpt.com/codex/tasks/task_e_68ac91ca8854832f86df1d15187c54d2