### PR TITLE
Handle login CSRF failures with explicit 422 response

### DIFF
--- a/docs/login_debug_log.md
+++ b/docs/login_debug_log.md
@@ -2,4 +2,6 @@
 
 The login API writes debug information to `logs/login_debug.log`. Each entry includes the identifier, client IP, whether the CSRF token was valid, and if a matching user was found. Passwords are redacted.
 
+When CSRF verification fails, the sanitized payload is logged separately and a brief "CSRF validation failed" note is appended to `login_debug.log`. The API returns a `422 Unprocessable Entity` status for these failures.
+
 Check this file when troubleshooting login issues.

--- a/public/api/login.php
+++ b/public/api/login.php
@@ -11,12 +11,12 @@ require_once __DIR__ . '/../../models/AuditLog.php';
 
 $ip         = $_SERVER['REMOTE_ADDR'] ?? '';
 $identifier = '';
-$csrfValid  = null;
+$csrfOk     = null;
 $userFound  = null;
 $context    = [
     'identifier' => $identifier,
     'ip' => $ip,
-    'csrf_valid' => $csrfValid,
+    'csrf_valid' => $csrfOk,
     'user_found' => $userFound,
     'password' => '[redacted]',
 ];
@@ -46,10 +46,11 @@ if (isset($data['username']) && is_string($data['username'])) {
 $context['identifier'] = $identifier;
 $password = isset($data['password']) && is_string($data['password']) ? $data['password'] : '';
 
-$csrfValid = csrf_verify($token);
-$context['csrf_valid'] = $csrfValid;
-if (!$csrfValid) {
+$csrfOk = csrf_verify($token);
+$context['csrf_valid'] = $csrfOk;
+if (!$csrfOk) {
     csrf_log_failure_payload($raw, $data);
+    error_log("CSRF validation failed\n", 3, __DIR__.'/../../logs/login_debug.log');
     $context['error'] = 'invalid_csrf';
     error_log(print_r($context, true), 3, __DIR__.'/../../logs/login_debug.log');
     return json_out(['ok' => false, 'error' => 'Invalid CSRF token'], 422);

--- a/tests/Integration/LoginValidationTest.php
+++ b/tests/Integration/LoginValidationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../TestHelpers/EndpointHarness.php';
+require_once __DIR__ . '/../../helpers/csrf_helpers.php';
 
 final class LoginValidationTest extends TestCase
 {
@@ -19,6 +20,23 @@ final class LoginValidationTest extends TestCase
         $this->assertFalse($res['ok'] ?? true);
         $this->assertSame('Missing fields', $res['error'] ?? '');
         $this->assertSame(400, http_response_code());
+        http_response_code(200);
+    }
+
+    public function testInvalidCsrfTokenReturns422(): void
+    {
+        $GLOBALS['__csrfLogFile'] = __DIR__ . '/../../logs/csrf_failures.log';
+        $GLOBALS['__csrfLogMaxBytes'] = 1024 * 1024;
+        $res = EndpointHarness::run(
+            __DIR__ . '/../../public/api/login.php',
+            ['csrf_token' => 'bad'],
+            [],
+            'POST',
+            ['json' => true, 'inject_csrf' => false]
+        );
+        $this->assertFalse($res['ok'] ?? true);
+        $this->assertSame('Invalid CSRF token', $res['error'] ?? '');
+        $this->assertSame(422, http_response_code());
         http_response_code(200);
     }
 }


### PR DESCRIPTION
## Summary
- capture CSRF verification outcome during login and log failures with context
- differentiate CSRF errors from credential issues by returning HTTP 422
- document CSRF logging behavior and new status code
- add integration test for invalid CSRF token

## Testing
- `php -l public/api/login.php`
- `./vendor/bin/phpunit tests/Integration/LoginValidationTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac97904d34832f9c0bfb923a9aa40d